### PR TITLE
Local news: fix links

### DIFF
--- a/openapi-local-news.yml
+++ b/openapi-local-news.yml
@@ -429,7 +429,7 @@ components:
         - `"en,es"`
         - `["en", "es"]`
 
-        To learn more, see [Enumerated parameters > Language](/docs/v3/api-reference/overview/enumerated_parameters#language-lang-and-not-lang).
+        To learn more, see [Enumerated parameters > Language](/docs/v3/api-reference/overview/enumerated-parameters#language-lang-and-not-lang).
       example: ["en", "es"]
 
     Sources:
@@ -875,7 +875,7 @@ components:
         - `"US,CA"`
         - `["US", "CA"]`
 
-        To learn more, see [Enumerated parameters > Country](/docs/v3/api-reference/overview/enumerated_parameters#country-country-and-not-country).
+        To learn more, see [Enumerated parameters > Country](/docs/v3/api-reference/overview/enumerated-parameters#country-country-and-not-country).
       example: ["US", "CA"]
 
     ## Search By params: `SearchByRequestDto` inherits `BaseModel` + has three new params:

--- a/openapi.yml
+++ b/openapi.yml
@@ -625,7 +625,7 @@ components:
 
         Example: `"en, es"`
 
-        To learn more, see [Enumerated parameters > Language](/docs/v3/api-reference/overview/enumerated_parameters#language-lang-and-not-lang).
+        To learn more, see [Enumerated parameters > Language](/docs/v3/api-reference/overview/enumerated-parameters#language-lang-and-not-lang).
       name: lang
       in: query
       required: false
@@ -647,7 +647,7 @@ components:
 
         Example: `"fr, de"`
 
-        To learn more, see [Enumerated parameters > Language](/docs/v3/api-reference/overview/enumerated_parameters#language-lang-and-not-lang).
+        To learn more, see [Enumerated parameters > Language](/docs/v3/api-reference/overview/enumerated-parameters#language-lang-and-not-lang).
       name: not_lang
       in: query
       required: false
@@ -693,7 +693,7 @@ components:
 
         Example: `"US, CA"`
 
-        To learn more, see [Enumerated parameters > Country](/docs/v3/api-reference/overview/enumerated_parameters#country-country-and-not-country).
+        To learn more, see [Enumerated parameters > Country](/docs/v3/api-reference/overview/enumerated-parameters#country-country-and-not-country).
       name: countries
       in: query
       required: false
@@ -715,7 +715,7 @@ components:
 
         Example:`"US, CA"`
 
-        To learn more, see [Enumerated parameters > Country](/docs/v3/api-reference/overview/enumerated_parameters#country-country-and-not-country).
+        To learn more, see [Enumerated parameters > Country](/docs/v3/api-reference/overview/enumerated-parameters#country-country-and-not-country).
       name: not_countries
       in: query
       required: false
@@ -1766,7 +1766,7 @@ components:
 
         Example: `"General News Outlets,Tech News and Updates"`
 
-        For a complete list of available news types, see [Enumerated parameters > News type](/docs/v3/api-reference/overview/enumerated_parameters#news-type-news-type).
+        For a complete list of available news types, see [Enumerated parameters > News type](/docs/v3/api-reference/overview/enumerated-parameters#news-type-news-type).
       name: news_type
       in: query
       required: false
@@ -3541,7 +3541,7 @@ components:
         - `"en,es"`
         - `["en", "es"]`
 
-        To learn more, see [Enumerated parameters > Language](/docs/v3/api-reference/overview/enumerated_parameters#language-lang-and-not-lang).
+        To learn more, see [Enumerated parameters > Language](/docs/v3/api-reference/overview/enumerated-parameters#language-lang-and-not-lang).
       example: ["en", "es"]
 
     NotLang:
@@ -3559,7 +3559,7 @@ components:
         - `"fr,de"`
         - `["fr", "de"]`
 
-        To learn more, see [Enumerated parameters > Language](/docs/v3/api-reference/overview/enumerated_parameters#language-lang-and-not-lang).
+        To learn more, see [Enumerated parameters > Language](/docs/v3/api-reference/overview/enumerated-parameters#language-lang-and-not-lang).
       example: ["fr", "de"]
 
     SearchIn:
@@ -3591,7 +3591,7 @@ components:
         - `"US,CA"`
         - `["US", "CA"]`
 
-        To learn more, see [Enumerated parameters > Country](/docs/v3/api-reference/overview/enumerated_parameters#country-country-and-not-country).
+        To learn more, see [Enumerated parameters > Country](/docs/v3/api-reference/overview/enumerated-parameters#country-country-and-not-country).
       example: ["US", "CA"]
 
     NotCountries:
@@ -3609,7 +3609,7 @@ components:
         - `"UK,FR"`
         - `["UK", "FR"]`
 
-        To learn more, see [Enumerated parameters > Country](/docs/v3/api-reference/overview/enumerated_parameters#country-country-and-not-country).
+        To learn more, see [Enumerated parameters > Country](/docs/v3/api-reference/overview/enumerated-parameters#country-country-and-not-country).
       example: ["UK", "FR"]
 
     Sources:
@@ -4445,7 +4445,7 @@ components:
         - `"General News Outlets,Tech News and Updates"`
         - `["General News Outlets", "Tech News and Updates"]`
 
-        For a complete list of available news types, see [Enumerated parameters > News type](/docs/v3/api-reference/overview/enumerated_parameters#news-type-news-type).
+        For a complete list of available news types, see [Enumerated parameters > News type](/docs/v3/api-reference/overview/enumerated-parameters#news-type-news-type).
 
       example: ["General News Outlets", "Tech News and Updates"]
 

--- a/v2/api-reference/overview/introduction.mdx
+++ b/v2/api-reference/overview/introduction.mdx
@@ -15,7 +15,7 @@ endpoint. It enables you to filter out millions of articles based on keywords,
 publish date, language, country of origin, and more.
 
 <Card
-  href="/docs/v2/api-reference/endpoints/search/search-news-get"
+  href="/v2/api-reference/endpoints/search/search-news-get"
   icon="caret-right"
 >
   Search news
@@ -29,7 +29,7 @@ filter the results on their country, language, topic, sources, etc, but no
 keywords.
 
 <Card
-  href="/docs/v2/api-reference/endpoints/latest_headlines/get-latest-headlines-get"
+  href="/v2/api-reference/endpoints/latest_headlines/get-latest-headlines-get"
   icon="caret-right"
 >
   Latest headlines
@@ -41,7 +41,7 @@ endpoint to fetch the list of all sources we have. You can filter the results
 using language, country, and topic.
 
 <Card
-  href="/docs/v2/api-reference/endpoints/sources/get-top-news-sources-get"
+  href="/v2/api-reference/endpoints/sources/get-top-news-sources-get"
   icon="caret-right"
 >
   Sources

--- a/v2/documentation/faq/overview.mdx
+++ b/v2/documentation/faq/overview.mdx
@@ -5,10 +5,10 @@ description: Find answers to the most asked questions
 ---
 
 <CardGroup cols={2}>
-  <Card icon="caret-right" href="/docs/v2/documentation/faq/product-faq">
+  <Card icon="caret-right" href="/v2/documentation/faq/product-faq">
     Product FAQ
   </Card>
-  <Card icon="caret-right" href="/docs/v2/documentation/faq/company-faq">
+  <Card icon="caret-right" href="/v2/documentation/faq/company-faq">
     Company FAQ
   </Card>
 </CardGroup>

--- a/v2/documentation/faq/product-faq.mdx
+++ b/v2/documentation/faq/product-faq.mdx
@@ -19,13 +19,13 @@ files. We do not serve any kind of UI at the moment.
 ## How to scroll through the results?
 
 By incrementing the `page`parameter you will be able to get all the results. Go
-check [this example](/docs/v2/documentation/how-to/scroll-through-pages).
+check [this example](/v2/documentation/how-to/scroll-through-pages).
 
 ## How to get more than 10,000 articles per call?
 
 You can do it only by breaking down your search into small parts by using the
 `published_date` or other parameters. You can check
-[this example](/docs/v2/documentation/how-to/get-more-than-10000-articles).
+[this example](/v2/documentation/how-to/get-more-than-10000-articles).
 
 ## Do you deduplicate news articles?
 

--- a/v2/documentation/guides-and-concepts/migrate-from-v1-rapid-api.mdx
+++ b/v2/documentation/guides-and-concepts/migrate-from-v1-rapid-api.mdx
@@ -53,8 +53,8 @@ Everything will be managed by our own platform.
 - Once you have an API key, you can start making API calls on at
   `https://api.newscatcherapi.com/v2/search`. Do not forget to put into headers
   => **x-api-key: \<YOUR_API_KEY>.** Check our
-  [Authentication page](/docs/v2/api-reference/overview/authentication) if
-  something is not clear to you.
+  [Authentication page](/v2/api-reference/overview/authentication) if something
+  is not clear to you.
 - If you want to upgrade to Paid Plan, from your account page you should see an
   "_Upgrade_" button. If you do not, just contact us at
   `mailto:artem@newscatcherapi.com`

--- a/v2/documentation/guides-and-concepts/use-news-api-v2-in-postman.mdx
+++ b/v2/documentation/guides-and-concepts/use-news-api-v2-in-postman.mdx
@@ -47,6 +47,5 @@ I added the Fork into my own Workspace. So, once it is done, you should see:
 ## What's next?
 
 Feel free to explore our News API by checking the
-[API Reference](/docs/v2/api-reference/endpoints) on each endpoint and use
-different combinations of filters and parameters to get the most relevant
-results.
+[API Reference](/v2/api-reference/endpoints) on each endpoint and use different
+combinations of filters and parameters to get the most relevant results.

--- a/v2/documentation/how-to/search-by-date-time.mdx
+++ b/v2/documentation/how-to/search-by-date-time.mdx
@@ -8,8 +8,8 @@ While searching for news articles you'll often need to filter out the results by
 their publication date. The articles returned by our News API have their
 publication date and time as an attribute : `published_date`. Using this
 information you can further drill down in your search queries on the
-[`v2/search`](/docs/v2/api-reference/endpoints/search/search-news-get) and
-[`v2/latest_headlines`](/docs/v2/api-reference/endpoints/latest_headlines/get-latest-headlines-get)
+[`v2/search`](/v2/api-reference/endpoints/search/search-news-get) and
+[`v2/latest_headlines`](/v2/api-reference/endpoints/latest_headlines/get-latest-headlines-get)
 endpoints.
 
 ## `/search`

--- a/v2/documentation/how-to/search-for-person-company-product.mdx
+++ b/v2/documentation/how-to/search-for-person-company-product.mdx
@@ -168,8 +168,8 @@ sources=gossipbucket.com,hollywoodlife.com,hollywoodreporter.com
 
 Use our `_/v2/sources_` endpoint to get a list of news sources available in our
 database. So, this can give you a hint of where to look for. On
-[this](/docs/v2/api-reference/endpoints/sources/get-top-news-sources-get) page,
-you will find more info about this endpoint.
+[this](/v2/api-reference/endpoints/sources/get-top-news-sources-get) page, you
+will find more info about this endpoint.
 
 **Example of the search intent**
 
@@ -178,8 +178,8 @@ do not know any business-oriented source._
 
 **Make a call with /v2/sources endpoint**
 
-Check the [Quickstart guide](/docs/v2/documentation/get-started/quickstart) to
-know how to make a call.
+Check the [Quickstart guide](/v2/documentation/get-started/quickstart) to know
+how to make a call.
 
 ```
 https://api.newscatcherapi.com

--- a/v2/documentation/tutorials/export-news-into-csv-with-python.mdx
+++ b/v2/documentation/tutorials/export-news-into-csv-with-python.mdx
@@ -85,7 +85,7 @@ and **Dogecoin.**
 In order to make a call, we need to set _headers_ and _parameters. In
 parameters,_ I am also filtering on **articles in English** as well as narrow
 down the search top 10 000 the **most trustful news sources** based on
-[_rank_ variable](/docs/v2/documentation/faq/product-faq#what-is-the-rank-parameter-how-do-you-calculate-it)
+[_rank_ variable](/v2/documentation/faq/product-faq#what-is-the-rank-parameter-how-do-you-calculate-it)
 . **Default timeperiod is set to 1 week**, so no need to define this parameter.
 
 ```python

--- a/v3/api-reference/libraries/python.mdx
+++ b/v3/api-reference/libraries/python.mdx
@@ -186,5 +186,5 @@ When an error occurs, you can access the following information from the
 
 ## Additional resources
 
-- [API Reference](/docs/v3/documentation/get-started/overview)
+- [API Reference](/v3/documentation/get-started/overview)
 - [PyPI Package](https://pypi.org/project/newscatcherapi-python-sdk/)

--- a/v3/api-reference/overview/errors.mdx
+++ b/v3/api-reference/overview/errors.mdx
@@ -12,15 +12,15 @@ indicate infrastructure issues.
 The following table provides a quick reference for the most common errors you
 might encounter while using the News API v3:
 
-| Status code | Status                | Description                                                                                             | Quick solution                                                                                                                             |
-| ----------- | --------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| 401         | Unauthorized          | Authentication failed. Typically due to an invalid or missing API key.                                  | Verify the API key is correct and included in the `x-api-token` header. Check your API key status with `/subscription`.                    |
-| 403         | Forbidden             | Request is valid, but the server refuses action. Could be due to permission issues or plan limitations. | Check your plan permissions and parameter usage. Ensure date ranges are within allowed limits. Contact support if needed.                  |
-| 408         | Request timeout       | The server did not receive a complete request message within the default timeout of 30 seconds.         | Check network connection, reduce request payload size if possible, narrow search query, implement retry logic.                             |
-| 422         | Validation error      | Server understands the request but cannot process it due to invalid input.                              | Ensure request data is correctly formatted and includes all required fields. Check date formats and parameter values.                      |
-| 429         | Too many requests     | Exceeded the allowed rate limit for API requests.                                                       | Implement request throttling and retry with exponential backoff. Consider upgrading your plan for higher limits.                           |
-| 499         | Unknown status code   | Client-side errors that do not fit standard HTTP status codes.                                          | Check for missing fields or incorrect parameters. Follow the [API Reference](/docs/v3/api-reference/endpoints/search/search-articles-get). |
-| 500         | Internal server error | Unexpected server-side issue. Could be due to a malformed payload or temporary server issues.           | Retry after a few minutes. Check the [status page](https://status.newscatcherapi.com) for known issues. Validate payload.                  |
+| Status code | Status                | Description                                                                                             | Quick solution                                                                                                                        |
+| ----------- | --------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| 401         | Unauthorized          | Authentication failed. Typically due to an invalid or missing API key.                                  | Verify the API key is correct and included in the `x-api-token` header. Check your API key status with `/subscription`.               |
+| 403         | Forbidden             | Request is valid, but the server refuses action. Could be due to permission issues or plan limitations. | Check your plan permissions and parameter usage. Ensure date ranges are within allowed limits. Contact support if needed.             |
+| 408         | Request timeout       | The server did not receive a complete request message within the default timeout of 30 seconds.         | Check network connection, reduce request payload size if possible, narrow search query, implement retry logic.                        |
+| 422         | Validation error      | Server understands the request but cannot process it due to invalid input.                              | Ensure request data is correctly formatted and includes all required fields. Check date formats and parameter values.                 |
+| 429         | Too many requests     | Exceeded the allowed rate limit for API requests.                                                       | Implement request throttling and retry with exponential backoff. Consider upgrading your plan for higher limits.                      |
+| 499         | Unknown status code   | Client-side errors that do not fit standard HTTP status codes.                                          | Check for missing fields or incorrect parameters. Follow the [API Reference](/v3/api-reference/endpoints/search/search-articles-get). |
+| 500         | Internal server error | Unexpected server-side issue. Could be due to a malformed payload or temporary server issues.           | Retry after a few minutes. Check the [status page](https://status.newscatcherapi.com) for known issues. Validate payload.             |
 
 ### Quick tips
 
@@ -30,4 +30,4 @@ might encounter while using the News API v3:
   (`422`).
 
 For detailed troubleshooting steps and best practices, refer to the
-[Error handling](/docs/v3/documentation/troubleshooting/error-handling) guide.
+[Error handling](/v3/documentation/troubleshooting/error-handling) guide.

--- a/v3/api-reference/overview/introduction.mdx
+++ b/v3/api-reference/overview/introduction.mdx
@@ -310,10 +310,10 @@ To start using News API v3:
 1. [Contact our sales team](https://www.newscatcherapi.com/pricing) to discuss
    your enterprise needs and obtain an API key.
 2. Once you have your API key, check out our
-   [Quickstart guide](/docs/v3/documentation/get-started/quickstart) to make
-   your first API call.
-3. Explore our [Documentation](/docs/v3/documentation/get-started/overview) to
-   unlock the full potential of the API and integrate it into your systems.
+   [Quickstart guide](/v3/documentation/get-started/quickstart) to make your
+   first API call.
+3. Explore our [Documentation](/v3/documentation/get-started/overview) to unlock
+   the full potential of the API and integrate it into your systems.
 
 For detailed information on request parameters and response formats, refer to
 the specific endpoint documentation in this API reference.

--- a/v3/documentation/get-started/libraries.mdx
+++ b/v3/documentation/get-started/libraries.mdx
@@ -9,7 +9,7 @@ description: NewsCatcher v3 SDKs
     icon="fa-python"
     iconType="brands"
     color="#306998"
-    href="/docs/v3/api-reference/libraries/python"
+    href="/v3/api-reference/libraries/python"
   >
     A comprehensive SDK for developing Python applications.
   </Card>
@@ -18,7 +18,7 @@ description: NewsCatcher v3 SDKs
     icon="fa-js"
     iconType="brands"
     color="#007ACC"
-    href="/docs/v3/api-reference/libraries/typescript"
+    href="/v3/api-reference/libraries/typescript"
   >
     A robust SDK for TypeScript development, with full type support.
   </Card>
@@ -27,7 +27,7 @@ description: NewsCatcher v3 SDKs
     icon="fa-java"
     iconType="brands"
     color="#5382A1"
-    href="/docs/v3/api-reference/libraries/java"
+    href="/v3/api-reference/libraries/java"
   >
     A powerful SDK for building Java applications and services.
   </Card>
@@ -36,7 +36,7 @@ description: NewsCatcher v3 SDKs
     icon="fa-golang"
     iconType="brands"
     color="#00ADD8"
-    href="/docs/v3/api-reference/libraries/go"
+    href="/v3/api-reference/libraries/go"
   >
     An efficient SDK for developing applications in Go.
   </Card>
@@ -45,7 +45,7 @@ description: NewsCatcher v3 SDKs
     icon="fa-microsoft"
     iconType="brands"
     color="#68217A"
-    href="/docs/v3/api-reference/libraries/csharp"
+    href="/v3/api-reference/libraries/csharp"
   >
     A feature-rich SDK for C# and .NET development.
   </Card>

--- a/v3/documentation/get-started/overview.mdx
+++ b/v3/documentation/get-started/overview.mdx
@@ -120,13 +120,12 @@ a two-step process:
 
 Once you have received your API key:
 
-1. Check out our
-   [Quickstart guide](/docs/v3/documentation/get-started/quickstart) to make
-   your first API call and understand the basics.
-2. Explore our [Documentation](/docs/v3/documentation) to unlock the full
-   potential of the API and integrate it into your systems.
-3. Refer to our [API Reference](/docs/v3/api-reference) for detailed information
-   on endpoints, request parameters, and response formats.
+1. Check out our [Quickstart guide](/v3/documentation/get-started/quickstart) to
+   make your first API call and understand the basics.
+2. Explore our [Documentation](/v3/documentation) to unlock the full potential
+   of the API and integrate it into your systems.
+3. Refer to our [API Reference](/v3/api-reference) for detailed information on
+   endpoints, request parameters, and response formats.
 
 Remember, the NewsCatcher News API v3 is more than just a tool - it's your
 partner in navigating the complex world of news data. Whether you're building

--- a/v3/documentation/get-started/quickstart.mdx
+++ b/v3/documentation/get-started/quickstart.mdx
@@ -203,14 +203,14 @@ explored some of its features, here are some next steps to enhance your usage:
 
 1. Explore other parameters like `predefined_sources`, `sort_by`, `iptc_tags`,
    or `iab_tags` to refine your searches.
-2. Check out our [API Reference](/docs/v3/api-reference) to learn about all
-   available endpoints and parameters.
+2. Check out our [API Reference](/v3/api-reference) to learn about all available
+   endpoints and parameters.
 3. Learn how to
-   [Implement pagination](/docs/v3/documentation/how-to/paginate-large-datasets)
-   to handle large datasets.
+   [Implement pagination](/v3/documentation/how-to/paginate-large-datasets) to
+   handle large datasets.
 4. Dive deeper into the
-   [NLP features](/docs/v3/documentation/guides-and-concepts/nlp-features) to
-   extract insights from the news articles.
+   [NLP features](/v3/documentation/guides-and-concepts/nlp-features) to extract
+   insights from the news articles.
 
 If you have any questions or need assistance, don't hesitate to contact our
 support team. Happy news hunting!

--- a/v3/documentation/guides-and-concepts/advanced-querying.mdx
+++ b/v3/documentation/guides-and-concepts/advanced-querying.mdx
@@ -142,7 +142,7 @@ q=("climate change" OR "global warming") AND (conference* OR summit) AND NEAR("P
 
 ## Related resources
 
-- [How to use boolean operators](/docs/v3/documentation/how-to/use-boolean-operators)
-- [Proximity search with NEAR](/docs/v3/documentation/how-to/search-with-near)
-- [API Reference](/docs/v3/api-reference/overview/introduction)
-- [How to optimize search with API parameters](/docs/v3/documentation/how-to/optimize-search)
+- [How to use boolean operators](/v3/documentation/how-to/use-boolean-operators)
+- [Proximity search with NEAR](/v3/documentation/how-to/search-with-near)
+- [API Reference](/v3/api-reference/overview/introduction)
+- [How to optimize search with API parameters](/v3/documentation/how-to/optimize-search)

--- a/v3/documentation/guides-and-concepts/articles-deduplication.mdx
+++ b/v3/documentation/guides-and-concepts/articles-deduplication.mdx
@@ -104,8 +104,7 @@ To exclude duplicate articles from your search results, set the
 need to know:
 
 - The deduplication feature is available only for the
-  [Search](/docs/v3/api-reference/endpoints/search/search-articles-get)
-  endpoint.
+  [Search](/v3/api-reference/endpoints/search/search-articles-get) endpoint.
 - It supports only English-language articles. If you apply the
   `exclude_duplicates` parameter to non-English articles, you get a validation
   error.
@@ -202,7 +201,7 @@ articles, they serve different purposes and are used in different contexts.
   or developments of a story over time.
 
 For more information on our clustering feature, check out
-[Clustering news articles](/docs/v3/documentation/guides-and-concepts/clustering-news-articles).
+[Clustering news articles](/v3/documentation/guides-and-concepts/clustering-news-articles).
 
 ## Related concepts
 

--- a/v3/documentation/guides-and-concepts/clustering-news-articles.mdx
+++ b/v3/documentation/guides-and-concepts/clustering-news-articles.mdx
@@ -67,8 +67,8 @@ Based on the similarity scores, we form clusters:
 ## How to use clustering
 
 Clustering is only available for the
-[Search](/docs/v3/api-reference/endpoints/search/search-articles-get) and
-[Latest Headlines](/docs/v3/api-reference/endpoints/latestheadlines/retrieve-latest-headlines-get)
+[Search](/v3/api-reference/endpoints/search/search-articles-get) and
+[Latest Headlines](/v3/api-reference/endpoints/latestheadlines/retrieve-latest-headlines-get)
 endpoints.
 
 ### Enable clustering
@@ -211,7 +211,7 @@ for deduplication to eliminate redundancy and ensure uniqueness in your article
 set.
 
 For more information on our deduplication feature, check out
-[Articles deduplication](/docs/v3/documentation/guides-and-concepts/articles-deduplication).
+[Articles deduplication](/v3/documentation/guides-and-concepts/articles-deduplication).
 
 ## Wrapping up
 

--- a/v3/documentation/guides-and-concepts/nlp-features.mdx
+++ b/v3/documentation/guides-and-concepts/nlp-features.mdx
@@ -253,7 +253,7 @@ You can use summaries in your searches and clustering:
 
   This approach can lead to more concise and focused clusters. For more
   information on clustering, see
-  [Clustering news articles](/docs/v3/documentation/guides-and-concepts/clustering-news-articles).
+  [Clustering news articles](/v3/documentation/guides-and-concepts/clustering-news-articles).
 
 ## Sentiment analysis
 
@@ -314,7 +314,7 @@ This query searches for articles about the tech industry that mention Apple or
 Microsoft as organizations and Tim Cook or Satya Nadella as persons.
 
 To learn more about NER, see
-[How to search by entity](/docs/v3/documentation/how-to/search-by-entity).
+[How to search by entity](/v3/documentation/how-to/search-by-entity).
 
 ## Content tagging
 
@@ -405,8 +405,8 @@ To maximize the effectiveness of NLP features in News API v3:
 
 ## Related resources
 
-- [How to use boolean operators](/docs/v3/documentation/how-to/use-boolean-operators)
-- [Proximity search with NEAR](/docs/v3/documentation/how-to/search-with-near)
-- [How to search by entity](/docs/v3/documentation/how-to/search-by-entity)
-- [Clustering news articles](/docs/v3/documentation/guides-and-concepts/clustering-news-articles)
-- [Articles deduplication](/docs/v3/documentation/guides-and-concepts/articles-deduplication)
+- [How to use boolean operators](/v3/documentation/how-to/use-boolean-operators)
+- [Proximity search with NEAR](/v3/documentation/how-to/search-with-near)
+- [How to search by entity](/v3/documentation/how-to/search-by-entity)
+- [Clustering news articles](/v3/documentation/guides-and-concepts/clustering-news-articles)
+- [Articles deduplication](/v3/documentation/guides-and-concepts/articles-deduplication)

--- a/v3/documentation/how-to/check-sources-coverage.mdx
+++ b/v3/documentation/how-to/check-sources-coverage.mdx
@@ -44,7 +44,7 @@ To refine your search and obtain addional source info, you can use:
 - `from_rank` and `to_rank`: Filter sources by their SEO rank.
 
 For detailed descriptions and usage of all parameters, refer to the
-[Sources reference documentation](/docs/v3/api-reference/endpoints/sources/retrieve-sources-post).
+[Sources reference documentation](/v3/api-reference/endpoints/sources/retrieve-sources-post).
 
 </Step>
 <Step title="Construct a query and make an API request">
@@ -378,6 +378,6 @@ you need for your application.
 
 ## See also
 
-- [Advanced querying techniques](/docs/v3/documentation/guides-and-concepts/advanced-querying)
-- [How to optimize search with API parameters](/docs/v3/documentation/how-to/optimize-search)
-- [API Reference: Sources endpoint](/docs/v3/api-reference/endpoints/sources/retrieve-sources-post)
+- [Advanced querying techniques](/v3/documentation/guides-and-concepts/advanced-querying)
+- [How to optimize search with API parameters](/v3/documentation/how-to/optimize-search)
+- [API Reference: Sources endpoint](/v3/api-reference/endpoints/sources/retrieve-sources-post)

--- a/v3/documentation/how-to/paginate-large-datasets.mdx
+++ b/v3/documentation/how-to/paginate-large-datasets.mdx
@@ -28,12 +28,12 @@ Before you begin, ensure you have:
 
 Pagination is available on the following endpoints:
 
-- [Search](/docs/v3/api-reference/endpoints/search/search-articles-get)
-- [Latest headlines](/docs/v3/api-reference/endpoints/latestheadlines/retrieve-latest-headlines-get)
-- [Authors](/docs/v3/api-reference/endpoints/authors/search-articles-by-author-get)
-- [Search by link](/docs/v3/api-reference/endpoints/searchlink/search-articles-by-links-or-ids-get)
-- [Search similar](/docs/v3/api-reference/endpoints/searchsimilar/search-similar-articles-get)
-- [Aggregation](/docs/v3/api-reference/endpoints/aggregation/get-aggregation-count-by-interval-get)
+- [Search](/v3/api-reference/endpoints/search/search-articles-get)
+- [Latest headlines](/v3/api-reference/endpoints/latestheadlines/retrieve-latest-headlines-get)
+- [Authors](/v3/api-reference/endpoints/authors/search-articles-by-author-get)
+- [Search by link](/v3/api-reference/endpoints/searchlink/search-articles-by-links-or-ids-get)
+- [Search similar](/v3/api-reference/endpoints/searchsimilar/search-similar-articles-get)
+- [Aggregation](/v3/api-reference/endpoints/aggregation/get-aggregation-count-by-interval-get)
 
 <Note>
   A single API response cannot return more than 1000 articles, so you should use
@@ -367,5 +367,5 @@ if __name__ == "__main__":
 
 ## See also
 
-- [Advanced querying techniques](/docs/v3/documentation/guides-and-concepts/advanced-querying)
-- [How to optimize search with API parameters](/docs/v3/documentation/how-to/optimize-search)
+- [Advanced querying techniques](/v3/documentation/guides-and-concepts/advanced-querying)
+- [How to optimize search with API parameters](/v3/documentation/how-to/optimize-search)

--- a/v3/documentation/how-to/search-by-entity.mdx
+++ b/v3/documentation/how-to/search-by-entity.mdx
@@ -77,7 +77,7 @@ parameter:
 ```
 
 To learn more about NLP capabilities in News API v3, see
-[NLP features](/docs/v3/documentation/guides-and-concepts/nlp-features).
+[NLP features](/v3/documentation/guides-and-concepts/nlp-features).
 
     </Step>
     <Step title="Make an API request with your entity query">
@@ -246,7 +246,7 @@ each other and combine with entity search:
 
 ## See also
 
-- [Advanced querying techniques](/docs/v3/documentation/guides-and-concepts/advanced-querying)
-- [How to use boolean operators](/docs/v3/documentation/how-to/use-boolean-operators)
-- [How to perform proximity search with NEAR](/docs/v3/documentation/how-to/search-with-near)
-- [Understanding the NLP features](/docs/v3/documentation/guides-and-concepts/nlp-features)
+- [Advanced querying techniques](/v3/documentation/guides-and-concepts/advanced-querying)
+- [How to use boolean operators](/v3/documentation/how-to/use-boolean-operators)
+- [How to perform proximity search with NEAR](/v3/documentation/how-to/search-with-near)
+- [Understanding the NLP features](/v3/documentation/guides-and-concepts/nlp-features)

--- a/v3/documentation/how-to/search-by-url.mdx
+++ b/v3/documentation/how-to/search-by-url.mdx
@@ -229,6 +229,6 @@ URL-based search is available on the following endpoints:
 
 ## See also
 
-- [Advanced querying techniques](/docs/v3/documentation/guides-and-concepts/advanced-querying)
-- [How to optimize search with API parameters](/docs/v3/documentation/how-to/optimize-search)
-- [API Reference: Search endpoint](/docs/v3/api-reference/endpoints/search/search-articles-post)
+- [Advanced querying techniques](/v3/documentation/guides-and-concepts/advanced-querying)
+- [How to optimize search with API parameters](/v3/documentation/how-to/optimize-search)
+- [API Reference: Search endpoint](/v3/api-reference/endpoints/search/search-articles-post)

--- a/v3/documentation/how-to/search-with-near.mdx
+++ b/v3/documentation/how-to/search-with-near.mdx
@@ -144,6 +144,6 @@ Before you begin, ensure you have:
 
 ## See also
 
-- [Advanced querying techniques](/docs/v3/documentation/guides-and-concepts/advanced-querying)
-- [How to use boolean operators](/docs/v3/documentation/how-to/use-boolean-operators)
-- [How to optimize search with API parameters](/docs/v3/documentation/how-to/optimize-search)
+- [Advanced querying techniques](/v3/documentation/guides-and-concepts/advanced-querying)
+- [How to use boolean operators](/v3/documentation/how-to/use-boolean-operators)
+- [How to optimize search with API parameters](/v3/documentation/how-to/optimize-search)

--- a/v3/documentation/how-to/use-boolean-operators.mdx
+++ b/v3/documentation/how-to/use-boolean-operators.mdx
@@ -145,5 +145,5 @@ topics with `NOT`.
 
 ## See also
 
-- [Advanced querying techniques](/docs/v3/documentation/guides-and-concepts/advanced-querying)
-- [How to optimize search with API parameters](/docs/v3/documentation/how-to/optimize-search)
+- [Advanced querying techniques](/v3/documentation/guides-and-concepts/advanced-querying)
+- [How to optimize search with API parameters](/v3/documentation/how-to/optimize-search)

--- a/v3/documentation/troubleshooting/error-handling.mdx
+++ b/v3/documentation/troubleshooting/error-handling.mdx
@@ -171,8 +171,7 @@ fit into standard HTTP status codes.
 
 1. Check your request payload for missing required fields.
 2. Ensure all parameters are correctly formatted and of the expected type.
-3. Review the [API documentation](/docs/v3/api-reference) for the correct
-   format.
+3. Review the [API documentation](/v3/api-reference) for the correct format.
 
 ### 500 Internal server error
 
@@ -212,12 +211,12 @@ page or a connection error.
 - **Follow security best practices:** Protect your API key, validate user
   inputs, and monitor for any unauthorized usage to prevent security issues.
 - **Stay updated:** Periodically check the
-  [API documentation](/docs/v3/api-reference) and
+  [API documentation](/v3/api-reference) and
   [status page](https://status.newscatcherapi.com) for updates or changes.
 
 ## Additional resources
 
-- [API Reference documentation](/docs/v3/api-reference)
-- [Rate limits and quotas](/docs/v3/api-reference/overview/rate-limits)
+- [API Reference documentation](/v3/api-reference)
+- [Rate limits and quotas](/v3/api-reference/overview/rate-limits)
 - [NewsCatcher status page](https://status.newscatcherapi.com)
-- [How to report bugs](/docs/v3/documentation/troubleshooting/report-bugs)
+- [How to report bugs](/v3/documentation/troubleshooting/report-bugs)

--- a/v3/local-news/overview/introduction.mdx
+++ b/v3/local-news/overview/introduction.mdx
@@ -36,7 +36,7 @@ Local News API offers three subscription tiers, each with specific capabilities:
 <Note>
   All plans include comprehensive NLP capabilities and support up to 2000
   sources per request. For detailed information about, visit the [Subscription
-  plans](/docs/v3/local-news/overview/subscription-plans) page.
+  plans](/v3/local-news/overview/subscription-plans) page.
 </Note>
 
 ## Base URL
@@ -170,8 +170,8 @@ response fields include:
 
 <Note>
   For detailed descriptions of all available response fields, refer to the
-  specific endpoint documentation in the
-  [Endpoints](/docs/v3/local-news/endpoints/) section.
+  specific endpoint documentation in the [Endpoints](/v3/local-news/endpoints/)
+  section.
 </Note>
 
 ### Example request
@@ -291,10 +291,11 @@ To start using Local News API:
 
 1. [Contact our sales team](https://www.newscatcherapi.com/pricing) to discuss
    your needs and obtain an API key.
-2. Once you have your API key, check out our Quick start guide to make your
-   first API call.
-3. Explore [Documentation](https://newscatcherapi.com/docs/v3/local-news) to
-   unlock the full potential of the API.
+2. Once you have your API key, check out our
+   [Quickstart guide](/v3/local-news/overview/quickstart) to make your first API
+   call.
+3. Explore [Documentation](/v3/local-news/overview/introduction) to unlock the
+   full potential of the API.
 
 For detailed information about request parameters and response formats, refer to
 the specific endpoint documentation in this API reference.

--- a/v3/local-news/overview/quickstart.mdx
+++ b/v3/local-news/overview/quickstart.mdx
@@ -125,7 +125,7 @@ Before you begin, make sure you have:
 
     <Note>
     To learn more about town association, see the [Town association
-    methods](/docs/v3/local-news/overview/town-association-methods).
+    methods](/v3/local-news/overview/town-association-methods).
     </Note>
 
   </Step>
@@ -258,14 +258,13 @@ Now that you've made your first calls to the Local News API, here are some next
 steps:
 
 1. Learn about
-   [advanced querying](/docs/v3/documentation/guides-and-concepts/advanced-querying)
+   [advanced querying](/v3/documentation/guides-and-concepts/advanced-querying)
    to refine your searches.
 2. Explore
-   [town association methods](/docs/v3/local-news/overview/town-association-methods)
+   [town association methods](/v3/local-news/overview/town-association-methods)
    for better location matching.
-3. Read about
-   [NLP features](/docs/v3/documentation/guides-and-concepts/nlp-features) to
-   extract insights from articles.
+3. Read about [NLP features](/v3/documentation/guides-and-concepts/nlp-features)
+   to extract insights from articles.
 
 If you have any questions or need assistance, please get in touch with our
 [support team](mailto:support@newscatcherapi.com).

--- a/v3/local-news/overview/town-association-methods.mdx
+++ b/v3/local-news/overview/town-association-methods.mdx
@@ -196,6 +196,6 @@ This method matches phrases like:
 
 ## See also
 
-- [Quickstart guide](/v3/local-news/quickstart)
+- [Quickstart guide](/v3/local-news/overview/quickstart)
 - [Subscription plans](/v3/local-news/overview/subscription-plans)
 - [Endpoints](/v3/local-news/endpoints)

--- a/v3/local-news/overview/town-association-methods.mdx
+++ b/v3/local-news/overview/town-association-methods.mdx
@@ -196,6 +196,6 @@ This method matches phrases like:
 
 ## See also
 
-- [Quickstart guide](/docs/v3/local-news/quickstart)
-- [Subscription plans](/docs/v3/local-news/overview/subscription-plans)
-- [Endpoints](/docs/v3/local-news/endpoints)
+- [Quickstart guide](/v3/local-news/quickstart)
+- [Subscription plans](/v3/local-news/overview/subscription-plans)
+- [Endpoints](/v3/local-news/endpoints)


### PR DESCRIPTION
In this pull request:

- For v2, v3, and local news API general articles, revert relative links from `/docs`.
- For v3 and Local New, fix the links to the enum parameters article.