### PR TITLE
Add tariffs_v2 event type to Events API

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -271,7 +271,8 @@
       "pages": [
         "v3/events/event-types/layoff",
         "v3/events/event-types/data-breach",
-        "v3/events/event-types/fundraising"
+        "v3/events/event-types/fundraising",
+        "v3/events/event-types/tariffs"
       ]
     },
     {

--- a/v3/events/event-types/tariffs.mdx
+++ b/v3/events/event-types/tariffs.mdx
@@ -1,0 +1,245 @@
+---
+title: Explore international tariff events
+sidebarTitle: Tariffs
+description:
+  Monitor and analyze global trade policy changes using tariff event data with
+  customizable search parameters.
+---
+
+Events API provides access to structured information about international tariffs
+and trade measures extracted from news articles. This guide explains how to
+discover available search fields, construct search requests, and understand the
+returned data.
+
+## Available search fields
+
+Get available search fields for tariff events using the discovery endpoint:
+
+```bash
+GET /api/events_info/get_event_fields?event_type=tariffs_v2
+```
+
+The endpoint returns the following fields that can be used for filtering search
+results. All fields are optional for search requests.
+
+### Common fields
+
+- `company_name`: The name of the company related to the tariff event, if
+  applicable.
+- `event_date`: The date when the tariff event occurred.
+- `extraction_date`: The date when the event was extracted from news sources.
+
+### Tariff-specific fields
+
+- `tariffs_v2.imposing_country_name`: The name of the country implementing the
+  tariff.
+- `tariffs_v2.imposing_country_code`: The ISO 3166-1 alpha-2 code of the country
+  implementing the tariff.
+- `tariffs_v2.targeted_country_names`: Names of countries targeted by the
+  tariff.
+- `tariffs_v2.targeted_country_codes`: ISO 3166-1 alpha-2 codes for countries
+  targeted by the tariff.
+- `tariffs_v2.measure_type`: Type of trade measure being implemented. Possible
+  values: new tariff, tariff increase, tariff reduction, retaliatory tariff,
+  import ban, quota, other trade restriction.
+- `tariffs_v2.main_tariff_rate`: The most significant tariff rate mentioned.
+- `tariffs_v2.tariff_rates`: List of tariff rate descriptions in the format "X%
+  on Y".
+- `tariffs_v2.previous_tariff_rate`: The tariff rates before this change.
+- `tariffs_v2.affected_industries`: Industries affected by the tariff using GICS
+  sectors.
+- `tariffs_v2.affected_products`: Specific products affected by the tariff or
+  trade measure.
+- `tariffs_v2.hs_product_categories`: Harmonized System (HS) sections of
+  products affected by the tariff.
+- `tariffs_v2.announcement_date`: Date when the tariff was announced.
+- `tariffs_v2.implementation_date`: Date when the tariff will be or was
+  implemented.
+- `tariffs_v2.estimated_trade_value`: The estimated value of trade affected by
+  the measure.
+- `tariffs_v2.policy_objective`: Stated policy objective for implementing the
+  tariff.
+- `tariffs_v2.trigger_event`: Description of what triggered a retaliatory
+  measure.
+- `tariffs_v2.relevance_score`: Rating of how directly the article addresses
+  specific tariff announcements.
+- `tariffs_v2.summary`: A comprehensive summary of the tariff announcement or
+  change.
+
+## Searching for events
+
+Use the search endpoint to find tariff events:
+
+```bash
+POST /api/events_search
+```
+
+### Basic request structure
+
+```json
+{
+  "event_type": "tariffs_v2",
+  "attach_articles_data": true,
+  "additional_filters": {
+    // search criteria using available fields
+  }
+}
+```
+
+### Using search fields
+
+Search by dates (absolute or relative):
+
+```json
+{
+  "event_type": "tariffs_v2",
+  "additional_filters": {
+    "extraction_date": {
+      "gte": "now-7d",
+      "lte": "now"
+    },
+    "tariffs_v2.implementation_date": {
+      "gte": "2025-01-01",
+      "lte": "2025-04-01"
+    }
+  }
+}
+```
+
+Search by countries and tariff rates:
+
+```json
+{
+  "event_type": "tariffs_v2",
+  "additional_filters": {
+    "tariffs_v2.imposing_country_code": "US",
+    "tariffs_v2.targeted_country_codes": ["CN"],
+    "tariffs_v2.main_tariff_rate": {
+      "gte": 20
+    }
+  }
+}
+```
+
+Search by measure type and affected industries:
+
+```json
+{
+  "event_type": "tariffs_v2",
+  "additional_filters": {
+    "tariffs_v2.measure_type": "retaliatory tariff",
+    "tariffs_v2.affected_industries": ["Materials"]
+  }
+}
+```
+
+Search by products and relevance:
+
+```json
+{
+  "event_type": "tariffs_v2",
+  "additional_filters": {
+    "tariffs_v2.affected_products": ["steel"],
+    "tariffs_v2.hs_product_categories": [
+      "XV: Base metals and articles of base metal"
+    ],
+    "tariffs_v2.relevance_score": "High"
+  }
+}
+```
+
+## Understanding the response
+
+The API returns matched events in this structure:
+
+```json
+{
+  "message": "Success",
+  "count": 20,
+  "events": [
+    {
+      "id": "event-id",
+      "event_type": "tariffs_v2",
+      "global_event_type": "TradePolicy",
+      "associated_article_ids": ["article-id-1", "article-id-2"],
+      "extraction_date": "2025-03-12 12:04:06",
+      "event_date": null,
+      "company_name": null,
+      "tariffs_v2": {
+        "summary": "Comprehensive summary of the tariff announcement",
+        "affected_products": ["aluminum", "steel"],
+        "imposing_country_name": "United States",
+        "affected_industries": ["Materials"],
+        "main_tariff_rate": 25,
+        "announcement_date": "2025/03/18",
+        "tariff_rates": ["25% on steel", "25% on aluminum"],
+        "targeted_country_codes": ["MX", "KR", "BR", "EU", "CN", "CA"],
+        "hs_product_categories": ["XV: Base metals and articles of base metal"],
+        "targeted_country_names": [
+          "European Union",
+          "Canada",
+          "China",
+          "South Korea",
+          "Brazil",
+          "Mexico"
+        ],
+        "relevance_score": "High",
+        "measure_type": "new tariff",
+        "imposing_country_code": "US",
+        "implementation_date": "2025/04/02"
+      },
+      "articles": [
+        // Article data when requested
+      ]
+    }
+  ]
+}
+```
+
+## Best practices
+
+1. Use `extraction_date` to monitor recently reported trade policy developments.
+2. Use `tariffs_v2.announcement_date` and `tariffs_v2.implementation_date` for
+   tracking policy timelines.
+3. Filter by both `tariffs_v2.imposing_country_code` and
+   `tariffs_v2.targeted_country_codes` to track bilateral trade tensions.
+4. Combine `tariffs_v2.affected_industries` and
+   `tariffs_v2.hs_product_categories` for sector-specific analysis.
+5. Use `tariffs_v2.measure_type` to distinguish between initial tariffs and
+   retaliatory measures.
+6. Use `tariffs_v2.main_tariff_rate` to filter for significant trade barriers.
+7. Filter by `tariffs_v2.relevance_score` to prioritize highly relevant
+   information.
+
+## Array field filtering
+
+When filtering for array fields, make sure to use array syntax even when
+searching for a single value:
+
+```json
+{
+  "event_type": "tariffs_v2",
+  "additional_filters": {
+    "tariffs_v2.targeted_country_codes": ["CA", "MX"], // Multiple values
+    "tariffs_v2.affected_industries": ["Materials"], // Single value, still using array
+    "tariffs_v2.hs_product_categories": [
+      "XV: Base metals and articles of base metal"
+    ]
+  }
+}
+```
+
+The following array fields require array syntax for filtering:
+
+- `tariffs_v2.targeted_country_codes`
+- `tariffs_v2.targeted_country_names`
+- `tariffs_v2.affected_industries`
+- `tariffs_v2.affected_products`
+- `tariffs_v2.hs_product_categories`
+- `tariffs_v2.tariff_rates`
+
+## See also
+
+- [Parameter formats](/v3/events/overview/parameter-formats)
+- [Working with articles](/v3/events/overview/working-with-articles)
+- [API reference](/v3/events/endpoints)

--- a/v3/events/events-api.yml
+++ b/v3/events/events-api.yml
@@ -193,7 +193,7 @@ components:
             properties:
               event_type:
                 type: string
-                enum: [layoff, data_breach, fundraising]
+                enum: [layoff, data_breach, fundraising, tariffs_v2]
                 description: The type of events to retrieve from the database.
               attach_articles_data:
                 type: boolean
@@ -212,10 +212,12 @@ components:
                     layoff: "#/components/schemas/LayoffFilters"
                     data_breach: "#/components/schemas/DataBreachFilters"
                     fundraising: "#/components/schemas/FundraisingFilters"
+                    tariffs_v2: "#/components/schemas/TariffsFilters"
                 oneOf:
                   - $ref: "#/components/schemas/LayoffFilters"
                   - $ref: "#/components/schemas/DataBreachFilters"
                   - $ref: "#/components/schemas/FundraisingFilters"
+                  - $ref: "#/components/schemas/TariffsFilters"
               additional_article_fields:
                 type: array
                 description: |
@@ -294,6 +296,7 @@ components:
                     - $ref: "#/components/schemas/LayoffEvent"
                     - $ref: "#/components/schemas/DataBreachEvent"
                     - $ref: "#/components/schemas/FundraisingEvent"
+                    - $ref: "#/components/schemas/TariffsEvent"
 
     SubscriptionResponse:
       description:
@@ -1236,6 +1239,164 @@ components:
                   description:
                     Summary of the funding event, up to 500 characters.
 
+    TariffsEvent:
+      title: Tariff
+      allOf:
+        - $ref: "#/components/schemas/BaseEvent"
+        - type: object
+          required:
+            - company_name
+          properties:
+            company_name:
+              type: string
+              description: Name of the company related to the tariff event.
+            tariffs_v2:
+              type: object
+              required:
+                - imposing_country_name
+                - imposing_country_code
+                - targeted_country_names
+                - targeted_country_codes
+                - measure_type
+                - affected_industries
+                - hs_product_categories
+                - main_tariff_rate
+                - summary
+              properties:
+                imposing_country_name:
+                  type: string
+                  description: The name of the country implementing the tariff.
+                imposing_country_code:
+                  type: string
+                  description:
+                    The ISO 3166-1 alpha-2 code of the country implementing the
+                    tariff.
+                targeted_country_names:
+                  type: array
+                  description: Names of countries targeted by the tariff.
+                  items:
+                    type: string
+                targeted_country_codes:
+                  type: array
+                  description:
+                    ISO 3166-1 alpha-2 codes for countries targeted by the
+                    tariff.
+                  items:
+                    type: string
+                measure_type:
+                  type: string
+                  enum:
+                    [
+                      "new tariff",
+                      "tariff increase",
+                      "tariff reduction",
+                      "retaliatory tariff",
+                      "import ban",
+                      "quota",
+                      "other trade restriction",
+                    ]
+                  description: Type of trade measure being implemented.
+                trigger_event:
+                  type: string
+                  description:
+                    Description of what triggered the retaliatory measure.
+                affected_industries:
+                  type: array
+                  description:
+                    Industries affected by the tariff or trade measure.
+                  items:
+                    type: string
+                    enum:
+                      [
+                        "Energy",
+                        "Materials",
+                        "Industrials",
+                        "Consumer Discretionary",
+                        "Consumer Staples",
+                        "Health Care",
+                        "Financials",
+                        "Information Technology",
+                        "Communication Services",
+                        "Utilities",
+                        "Real Estate",
+                      ]
+                affected_products:
+                  type: array
+                  description:
+                    Specific products affected by the tariff or trade measure.
+                  items:
+                    type: string
+                hs_product_categories:
+                  type: array
+                  description:
+                    Harmonized System (HS) sections of products affected by the
+                    tariff.
+                  items:
+                    type: string
+                    enum:
+                      [
+                        "I: Live animals; animal products",
+                        "II: Vegetable products",
+                        "III: Animal or vegetable fats and oils",
+                        "IV: Prepared foodstuffs; beverages, spirits, tobacco",
+                        "V: Mineral products",
+                        "VI: Products of the chemical or allied industries",
+                        "VII: Plastics and rubber",
+                        "VIII: Raw hides and skins, leather, furskins",
+                        "IX: Wood and articles of wood",
+                        "X: Pulp of wood; paper and paperboard",
+                        "XI: Textiles and textile articles",
+                        "XII: Footwear, headgear, umbrellas",
+                        "XIII: Articles of stone, ceramic products, glass",
+                        "XIV: Pearls, precious stones and metals",
+                        "XV: Base metals and articles of base metal",
+                        "XVI: Machinery and mechanical appliances",
+                        "XVII: Vehicles, aircraft, vessels",
+                        "XVIII: Optical, photographic, medical instruments",
+                        "XIX: Arms and ammunition",
+                        "XX: Miscellaneous manufactured articles",
+                        "XXI: Works of art, collectors' pieces",
+                      ]
+                tariff_rates:
+                  type: array
+                  description: List of tariff rate descriptions.
+                  items:
+                    type: string
+                main_tariff_rate:
+                  type: number
+                  description: The most significant tariff rate mentioned.
+                previous_tariff_rate:
+                  type: string
+                  description: The tariff rates before this change.
+                announcement_date:
+                  type: string
+                  description:
+                    Date when the tariff or trade measure was announced.
+                implementation_date:
+                  type: string
+                  description:
+                    Date when the tariff or trade measure will be or was
+                    implemented.
+                estimated_trade_value:
+                  type: string
+                  description:
+                    The estimated value of trade affected by the measure.
+                policy_objective:
+                  type: string
+                  description:
+                    Stated policy objective for implementing the tariff.
+                relevance_score:
+                  type: string
+                  enum: ["Low", "Medium", "High"]
+                  description:
+                    Rating of how directly the article addresses specific tariff
+                    announcements.
+                summary:
+                  type: string
+                  description:
+                    A comprehensive summary of the tariff announcement or
+                    change.
+
     # Filter Schemas
     DateRangeFilter:
       type: object
@@ -1427,6 +1588,146 @@ components:
           type: string
           description: |
             The valuation of the company in digits at the time of funding (e.g., 1000000, 1000000000).
+
+    TariffsFilters:
+      title: Tariffs
+      type: object
+      properties:
+        company_name:
+          type: string
+          description: The name of the company related to the tariff event.
+        event_date:
+          allOf:
+            - $ref: "#/components/schemas/DateRangeFilter"
+            - description: |
+                The date when the tariff event occurred. Accepts both absolute dates (YYYY-MM-DD) and relative dates (e.g., "now", "now-30d"). Default: Last 30 days.
+        extraction_date:
+          allOf:
+            - $ref: "#/components/schemas/DateRangeFilter"
+            - description: |
+                The date when the event was extracted from news sources. Accepts both absolute dates (YYYY-MM-DD) and relative dates.
+        "tariffs_v2.affected_industries":
+          type: string
+          description: |
+            Industries affected by the tariff or trade measure, using GICS sectors.
+          enum:
+            [
+              "Energy",
+              "Materials",
+              "Industrials",
+              "Consumer Discretionary",
+              "Consumer Staples",
+              "Health Care",
+              "Financials",
+              "Information Technology",
+              "Communication Services",
+              "Utilities",
+              "Real Estate",
+            ]
+        "tariffs_v2.affected_products":
+          type: string
+          description: |
+            The specific products affected by the tariff or trade measure.
+        "tariffs_v2.announcement_date":
+          type: string
+          description: |
+            Date when the tariff or trade measure was announced, in YYYY/MM/DD format.
+        "tariffs_v2.estimated_trade_value":
+          type: string
+          description: |
+            The estimated value of trade affected by the measure.
+        "tariffs_v2.hs_product_categories":
+          type: string
+          description: |
+            Harmonized System (HS) sections of products affected by the tariff.
+          enum:
+            [
+              "I: Live animals; animal products",
+              "II: Vegetable products",
+              "III: Animal or vegetable fats and oils",
+              "IV: Prepared foodstuffs; beverages, spirits, tobacco",
+              "V: Mineral products",
+              "VI: Products of the chemical or allied industries",
+              "VII: Plastics and rubber",
+              "VIII: Raw hides and skins, leather, furskins",
+              "IX: Wood and articles of wood",
+              "X: Pulp of wood; paper and paperboard",
+              "XI: Textiles and textile articles",
+              "XII: Footwear, headgear, umbrellas",
+              "XIII: Articles of stone, ceramic products, glass",
+              "XIV: Pearls, precious stones and metals",
+              "XV: Base metals and articles of base metal",
+              "XVI: Machinery and mechanical appliances",
+              "XVII: Vehicles, aircraft, vessels",
+              "XVIII: Optical, photographic, medical instruments",
+              "XIX: Arms and ammunition",
+              "XX: Miscellaneous manufactured articles",
+              "XXI: Works of art, collectors' pieces",
+            ]
+        "tariffs_v2.implementation_date":
+          type: string
+          description: |
+            Date when the tariff or trade measure will be or was implemented, in YYYY/MM/DD format.
+        "tariffs_v2.imposing_country_code":
+          type: string
+          description: |
+            The ISO 3166-1 alpha-2 code of the country implementing the tariff.
+        "tariffs_v2.imposing_country_name":
+          type: string
+          description: |
+            The name of the country implementing the tariff.
+        "tariffs_v2.main_tariff_rate":
+          allOf:
+            - $ref: "#/components/schemas/NumberRangeFilter"
+            - description: |
+                The most significant tariff rate mentioned.
+        "tariffs_v2.measure_type":
+          type: string
+          description: |
+            Type of trade measure being implemented.
+          enum:
+            [
+              "new tariff",
+              "tariff increase",
+              "tariff reduction",
+              "retaliatory tariff",
+              "import ban",
+              "quota",
+              "other trade restriction",
+            ]
+        "tariffs_v2.policy_objective":
+          type: string
+          description: |
+            Stated policy objective for implementing the tariff.
+        "tariffs_v2.previous_tariff_rate":
+          type: string
+          description: |
+            The tariff rates before this change.
+        "tariffs_v2.relevance_score":
+          type: string
+          description: |
+            Rating of how directly the article addresses specific tariff announcements.
+          enum: ["Low", "Medium", "High"]
+        "tariffs_v2.summary":
+          type: string
+          description: |
+            A comprehensive summary of the tariff announcement or change.
+        "tariffs_v2.targeted_country_codes":
+          type: string
+          description: |
+            ISO 3166-1 alpha-2 codes for countries targeted by the tariff.
+        "tariffs_v2.targeted_country_names":
+          type: string
+          description: |
+            Names of countries targeted by the tariff.
+        "tariffs_v2.tariff_rates":
+          type: string
+          description: |
+            List of tariff rate descriptions.
+        "tariffs_v2.trigger_event":
+          type: string
+          description: |
+            Description of what triggered the retaliatory measure.
 
     # Events Search Request
     SubscriptionResponseDto:

--- a/v3/events/events-api.yml
+++ b/v3/events/events-api.yml
@@ -8,11 +8,12 @@ info:
 
     ## Public events
 
-    Three event types are available to all API users:
+    Four event types are available to all API users:
 
     - Layoffs: Company workforce reductions
     - Data Breaches: Information security incidents
     - Fundraising: Investment and funding rounds
+    - Tariffs: International trade measures and tariff policy changes
 
     Additional event types are available through custom implementations. Contact us for information about custom event development and access.
 
@@ -22,7 +23,7 @@ info:
     - Entity deduplication across multiple news sources
     - Date range filtering with relative and absolute dates
     - Company and location-based filtering
-    - Event-specific field filtering (e.g., layoff size, funding amount)
+    - Event-specific field filtering (e.g., layoff size, funding amount, tariff rates)
     - Optional inclusion of source article data
   version: 1.0.0
   termsOfService: https://newscatcherapi.com/terms-of-service

--- a/v3/events/events-api.yml
+++ b/v3/events/events-api.yml
@@ -1249,7 +1249,9 @@ components:
           properties:
             company_name:
               type: string
-              description: Name of the company related to the tariff event.
+              nullable: true
+              description: |
+                Name of the company related to the tariff event, if applicable.
             tariffs_v2:
               type: object
               required:

--- a/v3/events/events-api.yml
+++ b/v3/events/events-api.yml
@@ -265,6 +265,7 @@ components:
               - $ref: "#/components/schemas/LayoffFieldsResponse"
               - $ref: "#/components/schemas/DataBreachFieldsResponse"
               - $ref: "#/components/schemas/FundraisingFieldsResponse"
+              - $ref: "#/components/schemas/TariffsFieldsResponse"
 
     EventsSearchResponse:
       description: Search results containing matched events.
@@ -674,6 +675,126 @@ components:
                   allOf:
                     - $ref: "#/components/schemas/StringFieldType"
                     - description: Company valuation at the time of funding.
+
+    TariffsFieldsResponse:
+      title: Tariffs Fields
+      allOf:
+        - $ref: "#/components/schemas/BaseFieldsResponse"
+        - type: object
+          properties:
+            fields:
+              type: object
+              required:
+                - company_name
+                - event_date
+                - extraction_date
+              properties:
+                company_name:
+                  allOf:
+                    - $ref: "#/components/schemas/StringFieldType"
+                    - description:
+                        Name of the company related to the tariff event.
+                event_date:
+                  allOf:
+                    - $ref: "#/components/schemas/DateFieldType"
+                    - description: Date when the tariff event occurred.
+                extraction_date:
+                  allOf:
+                    - $ref: "#/components/schemas/DateFieldType"
+                    - description:
+                        Date when the event was extracted from news sources.
+                "tariffs_v2.affected_industries":
+                  allOf:
+                    - $ref: "#/components/schemas/StringFieldType"
+                    - description:
+                        Industries affected by the tariff or trade measure.
+                "tariffs_v2.affected_products":
+                  allOf:
+                    - $ref: "#/components/schemas/StringFieldType"
+                    - description:
+                        Specific products affected by the tariff or trade
+                        measure.
+                "tariffs_v2.announcement_date":
+                  allOf:
+                    - $ref: "#/components/schemas/StringFieldType"
+                    - description:
+                        Date when the tariff or trade measure was announced.
+                "tariffs_v2.estimated_trade_value":
+                  allOf:
+                    - $ref: "#/components/schemas/StringFieldType"
+                    - description:
+                        The estimated value of trade affected by the measure.
+                "tariffs_v2.hs_product_categories":
+                  allOf:
+                    - $ref: "#/components/schemas/StringFieldType"
+                    - description:
+                        Harmonized System (HS) sections of products affected by
+                        the tariff.
+                "tariffs_v2.implementation_date":
+                  allOf:
+                    - $ref: "#/components/schemas/StringFieldType"
+                    - description:
+                        Date when the tariff or trade measure will be or was
+                        implemented.
+                "tariffs_v2.imposing_country_code":
+                  allOf:
+                    - $ref: "#/components/schemas/StringFieldType"
+                    - description:
+                        The ISO 3166-1 alpha-2 code of the country implementing
+                        the tariff.
+                "tariffs_v2.imposing_country_name":
+                  allOf:
+                    - $ref: "#/components/schemas/StringFieldType"
+                    - description:
+                        The name of the country implementing the tariff.
+                "tariffs_v2.main_tariff_rate":
+                  allOf:
+                    - $ref: "#/components/schemas/NumberFieldType"
+                    - description: The most significant tariff rate mentioned.
+                "tariffs_v2.measure_type":
+                  allOf:
+                    - $ref: "#/components/schemas/StringFieldType"
+                    - description: Type of trade measure being implemented.
+                "tariffs_v2.policy_objective":
+                  allOf:
+                    - $ref: "#/components/schemas/StringFieldType"
+                    - description:
+                        Stated policy objective for implementing the tariff.
+                "tariffs_v2.previous_tariff_rate":
+                  allOf:
+                    - $ref: "#/components/schemas/StringFieldType"
+                    - description: The tariff rates before this change.
+                "tariffs_v2.relevance_score":
+                  allOf:
+                    - $ref: "#/components/schemas/StringFieldType"
+                    - description:
+                        Rating of how directly the article addresses specific
+                        tariff announcements.
+                "tariffs_v2.summary":
+                  allOf:
+                    - $ref: "#/components/schemas/StringFieldType"
+                    - description:
+                        A comprehensive summary of the tariff announcement or
+                        change.
+                "tariffs_v2.targeted_country_codes":
+                  allOf:
+                    - $ref: "#/components/schemas/StringFieldType"
+                    - description:
+                        ISO 3166-1 alpha-2 codes for countries targeted by the
+                        tariff.
+                "tariffs_v2.targeted_country_names":
+                  allOf:
+                    - $ref: "#/components/schemas/StringFieldType"
+                    - description: Names of countries targeted by the tariff.
+                "tariffs_v2.tariff_rates":
+                  allOf:
+                    - $ref: "#/components/schemas/StringFieldType"
+                    - description: List of tariff rate descriptions.
+                "tariffs_v2.trigger_event":
+                  allOf:
+                    - $ref: "#/components/schemas/StringFieldType"
+                    - description:
+                        Description of what triggered the retaliatory measure.
 
     BaseEvent:
       type: object

--- a/v3/events/overview/introduction.mdx
+++ b/v3/events/overview/introduction.mdx
@@ -312,6 +312,7 @@ Events available to all customers:
 - [Layoff](/v3/events/event-types/layoff)
 - [Data Breach](/v3/events/event-types/data-breach)
 - [Fundraising](/v3/events/event-types/fundraising)
+- [Tariffs](/v3/events/event-types/tariffs)
 
 ### Custom events
 


### PR DESCRIPTION
This PR adds support for the new tariffs_v2 event type to the Events API OpenAPI specification and documentation. The tariffs_v2 event type allows users to monitor and analyze international trade policy changes and tariff announcements.

## Changes
- Add TariffsFieldsResponse schema for the /api/events_info/get_event_fields endpoint.
- Add TariffsEvent and TariffsFilters schemas for the /api/events_search endpoint.
- Update API documentation in the info section to include tariff events.
- Create a new documentation page for the tariffs event type.

## Testing
- Verified schema against actual API responses
- Ensured proper handling of nullable fields
- Validated array field filtering requirements