### PR TITLE
Document top_n_articles feature and resolve response structure ambiguity

### DIFF
--- a/v3/api-reference/news-api-v3.yml
+++ b/v3/api-reference/news-api-v3.yml
@@ -305,6 +305,7 @@ paths:
         - $ref: "#/components/parameters/ToRank"
         - $ref: "#/components/parameters/Page"
         - $ref: "#/components/parameters/PageSize"
+        - $ref: "#/components/parameters/TopNArticles"
         - $ref: "#/components/parameters/IncludeNlpData"
         - $ref: "#/components/parameters/HasNlp"
         - $ref: "#/components/parameters/Theme"
@@ -1970,6 +1971,14 @@ components:
           summary: Multiple news types
           value: "General News Outlets,Tech News and Updates"
 
+    # Breaking news
+    TopNArticles:
+      name: top_n_articles
+      in: query
+      schema:
+        $ref: "#/components/schemas/TopNArticles"
+      required: false
+
   requestBodies:
     AggregationRequestBody:
       description:
@@ -2301,6 +2310,8 @@ components:
                 $ref: "#/components/schemas/Page"
               page_size:
                 $ref: "#/components/schemas/PageSize"
+              top_n_articles:
+                $ref: "#/components/schemas/TopNArticles"
               include_nlp_data:
                 $ref: "#/components/schemas/IncludeNlpData"
               has_nlp:
@@ -3333,12 +3344,14 @@ components:
         - $ref: "#/components/schemas/BaseSearchResponseDto"
         - type: object
           properties:
-            articles:
-              title: Articles
-              description: A list of articles matching the search criteria.
+            breaking_news_events:
+              title: Breaking News Events
+              description:
+                A list of breaking news events, each containing relevant
+                articles.
               type: array
               items:
-                $ref: "#/components/schemas/BreakingNewsArticleEntity"
+                $ref: "#/components/schemas/BreakingNewsEventEntity"
               default: []
             user_input:
               $ref: "#/components/schemas/UserInputDto"
@@ -3383,6 +3396,32 @@ components:
             user_input:
               $ref: "#/components/schemas/UserInputDto"
 
+    BreakingNewsEventEntity:
+      title: Breaking News Event Object
+      description: |
+        The data model representing a breaking news event with its associated articles.
+      required:
+        - event_id
+        - articles_count
+        - articles
+      type: object
+      properties:
+        event_id:
+          title: Event ID
+          description: Unique identifier for the breaking news event/cluster.
+          type: string
+        articles_count:
+          title: Articles Count
+          description: Number of articles in this breaking news cluster.
+          type: integer
+        articles:
+          title: Articles
+          description: The articles associated with this breaking news event.
+          type: array
+          items:
+            $ref: "#/components/schemas/BreakingNewsArticleEntity"
+          default: []
+
     BreakingNewsArticleEntity:
       title: Breaking News Article Object
       description: |
@@ -3397,8 +3436,6 @@ components:
         - content
         - id
         - score
-        - breaking_news_event_id
-        - breaking_news_articles_count
       type: object
       properties:
         title:
@@ -3542,14 +3579,6 @@ components:
           title: Score
           description: The relevance score of the article.
           type: number
-        breaking_news_event_id:
-          title: Breaking News Event ID
-          description: Unique identifier for the breaking news event/cluster
-          type: string
-        breaking_news_articles_count:
-          title: Breaking News Articles Count
-          description: Number of articles in this breaking news cluster
-          type: integer
 
     SimilarArticleEntity:
       title: Search Similar Article Object
@@ -4650,6 +4679,20 @@ components:
       description: |
         If true, filters results to include only news domains.
       example: true
+
+    # Breaking news
+    TopNArticles:
+      type: integer
+      minimum: 1
+      maximum: 100
+      default: 1
+      description: |
+        Controls the number of top articles to include for each breaking news event.
+
+        **Important limitations**: 
+        - Maximum value is 100.
+        - The product of `top_n_articles` x `page_size` must not exceed 1,000 (total articles limit).
+      example: 5
 
   securitySchemes:
     ApiKeyAuth:

--- a/v3/documentation/guides-and-concepts/breaking-news.mdx
+++ b/v3/documentation/guides-and-concepts/breaking-news.mdx
@@ -34,7 +34,7 @@ Our breaking news detection works through several interconnected stages:
     their content similarity.
   </Step>
   <Step title="Validation">
-    Each cluster undergoes analysis for breaking news signals, including: 
+    Each cluster undergoes analysis for breaking news signals, including:
     - Publication frequency (sudden spikes in coverage) 
     - Source diversity (coverage across multiple publishers) 
     - Coverage quality (presence of high-ranking news sources)
@@ -82,7 +82,7 @@ https://v3-api.newscatcherapi.com/api/breaking_news
 <CodeGroup>
 
 ```bash GET
-curl -X GET "https://v3-api.newscatcherapi.com/api/breaking_news?theme=Business&include_nlp_data=true" \
+curl -X GET "https://v3-api.newscatcherapi.com/api/breaking_news?theme=Business&page_size=100&top_n_articles=5" \
   -H "x-api-token: YOUR_API_KEY"
 ```
 
@@ -91,8 +91,9 @@ curl -X POST "https://v3-api.newscatcherapi.com/api/breaking_news" \
   -H "Content-Type: application/json" \
   -H "x-api-token: YOUR_API_KEY" \
   -d '{
-    "include_nlp_data": true,
-    "theme": "Business"
+    "theme": "Business",
+    "page_size": 100,
+    "top_n_articles": 5
   }'
 ```
 
@@ -105,44 +106,41 @@ The API returns a JSON object with the following structure:
 ```json
 {
   "status": "ok",
-  "total_hits": 318,
+  "total_hits": 465,
   "page": 1,
-  "total_pages": 318,
-  "page_size": 1,
-  "articles": [
+  "total_pages": 5,
+  "page_size": 100,
+  "breaking_news_events": [
     {
-      "title": "Article Title",
-      "author": "Author Name",
-      "published_date": "2025-03-31 14:11:04",
-      // ... standard article fields ...
-      "breaking_news_event_id": "12520934405688386290",
-      "breaking_news_articles_count": 766
+      "event_id": "15610469432059813057",
+      "articles_count": 5842,
+      "articles": [
+        // Individual articles within this breaking news event
+      ]
     }
-  ],
-  "user_input": {
-    // Echo of request parameters
-  }
+  ]
 }
 ```
 
-Each article in the response represents the top article from a unique breaking
-news cluster. The additional fields specific to the `/breaking_news` endpoint
-include:
+The response contains an array of breaking news events, each with its associated
+articles. The structure includes:
 
-- `breaking_news_event_id`: Unique identifier for the breaking news
-  event/cluster.
-- `breaking_news_articles_count`: Number of articles in this breaking news
-  cluster.
+- `breaking_news_events`: Array of breaking news events, each representing a
+  significant news cluster
+  - `event_id`: Unique identifier for the breaking news event/cluster
+  - `articles_count`: Total number of articles in this breaking news cluster
+  - `articles`: Array of articles related to this breaking news event (limited
+    by the `top_n_articles` parameter)
 
 ### Comparison with other endpoints
 
-| Endpoint        | Breaking news                                       | Search                                         | Latest headlines                                        |
-| --------------- | --------------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------- |
-| Purpose         | Discover emerging stories with significant traction | Find specific content matching search criteria | Retrieve recent headlines for the specified time period |
-| Time scope      | Fixed at 24 hours                                   | Configurable with `from_` and `to_`            | Configurable with `when`                                |
-| Result grouping | Clustered by event                                  | Individual articles                            | Individual articles                                     |
-| Primary sorting | By cluster size (coverage volume)                   | By relevance, date, or rank                    | By publication date                                     |
-| Best for        | Discovering important new stories                   | Finding specific content                       | Monitoring regular updates                              |
+| Endpoint        | Breaking news                                           | Search                                         | Latest headlines                                        |
+| --------------- | ------------------------------------------------------- | ---------------------------------------------- | ------------------------------------------------------- |
+| Purpose         | Discover emerging stories with significant traction     | Find specific content matching search criteria | Retrieve recent headlines for the specified time period |
+| Time scope      | Fixed at 24 hours                                       | Configurable with `from_` and `to_`            | Configurable with `when`                                |
+| Result grouping | Clustered by event with configurable articles per event | Individual articles                            | Individual articles                                     |
+| Primary sorting | By cluster size (coverage volume)                       | By relevance, date, or rank                    | By publication date                                     |
+| Best for        | Discovering important new stories                       | Finding specific content                       | Monitoring regular updates                              |
 
 ## Use cases
 
@@ -173,7 +171,6 @@ faster.
 Organizations can quickly identify emerging crises related to their industry,
 brand, or interests. The breaking news endpoint helps detect sudden increases in
 coverage about topics of concern, enabling faster response.
-
 
 ## Related resources
 


### PR DESCRIPTION
This PR adds a new `top_n_articles` parameter to the` /breaking_news` endpoint and resolves ambiguity in the API response structure.

### Changes:

- Add new `top_n_articles` parameter to control the number of articles per breaking news event
- Document existing validation limit where total articles (top_n_articles × page_size) cannot exceed 1000
- Fix ambiguous naming by changing top-level `articles` to `breaking_news_events` to avoid duplicate array names
- Improve field naming with more concise versions (as we have the `breaking_news_events` parent):
   - `breaking_news_event_id` → `event_id`
   - `breaking_news_articles_count` → `articles_count`
- Update documentation examples and response format description
- Update comparison table to reflect new result grouping capabilities

### API response changes:

Before:
```json
{
  "articles": [
    {
      "breaking_news_event_id": "123",
      "breaking_news_articles_count": 42,
      // article data
    }
  ]
}
```

After:
```json
{
  "breaking_news_events": [
    {
      "event_id": "123",
      "articles_count": 42,
      "articles": [
        // article data
      ]
    }
  ]
}
```

This structure better represents the data relationships and provides a more intuitive developer experience.