### PR TITLE
Add translation features documentation

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -114,7 +114,7 @@
         "v3/documentation/how-to/search-with-near",
         "v3/documentation/how-to/search-by-entity",
         "v3/documentation/how-to/search-by-url",
-        "v3/documentation/how-to/optimize-search",
+        "v3/documentation/how-to/work-with-translations",
         "v3/documentation/how-to/paginate-large-datasets",
         "v3/documentation/how-to/retrieve-more-than-10k-articles",
         "v3/documentation/how-to/check-sources-coverage"

--- a/v3/api-reference/news-api-v3.yml
+++ b/v3/api-reference/news-api-v3.yml
@@ -95,6 +95,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/Q"
         - $ref: "#/components/parameters/SearchIn"
+        - $ref: "#/components/parameters/IncludeTranslationFields"
         - $ref: "#/components/parameters/PredefinedSources"
         - $ref: "#/components/parameters/SourceName"
         - $ref: "#/components/parameters/Sources"
@@ -227,6 +228,7 @@ paths:
         - $ref: "#/components/parameters/ClusteringEnabled"
         - $ref: "#/components/parameters/ClusteringVariable"
         - $ref: "#/components/parameters/ClusteringThreshold"
+        - $ref: "#/components/parameters/IncludeTranslationFields"
         - $ref: "#/components/parameters/IncludeNlpData"
         - $ref: "#/components/parameters/HasNlp"
         - $ref: "#/components/parameters/Theme"
@@ -306,6 +308,7 @@ paths:
         - $ref: "#/components/parameters/Page"
         - $ref: "#/components/parameters/PageSize"
         - $ref: "#/components/parameters/TopNArticles"
+        - $ref: "#/components/parameters/IncludeTranslationFields"
         - $ref: "#/components/parameters/IncludeNlpData"
         - $ref: "#/components/parameters/HasNlp"
         - $ref: "#/components/parameters/Theme"
@@ -401,6 +404,7 @@ paths:
         - $ref: "#/components/parameters/WordCountMax"
         - $ref: "#/components/parameters/Page"
         - $ref: "#/components/parameters/PageSize"
+        - $ref: "#/components/parameters/IncludeTranslationFields"
         - $ref: "#/components/parameters/IncludeNlpData"
         - $ref: "#/components/parameters/HasNlp"
         - $ref: "#/components/parameters/Theme"
@@ -560,6 +564,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/Q"
         - $ref: "#/components/parameters/SearchIn"
+        - $ref: "#/components/parameters/IncludeTranslationFields"
         - $ref: "#/components/parameters/IncludeSimilarDocuments"
         - $ref: "#/components/parameters/SimilarDocumentsNumber"
         - $ref: "#/components/parameters/SimilarDocumentsFields"
@@ -923,27 +928,18 @@ components:
           value: fr,de
 
     SearchIn:
-      description: |
-        The article fields to search in. To search in multiple fields, use a comma-separated string. 
-
-        Example: `"title, summary"`
-
-        **Note**: The `summary` option is available if NLP is enabled in your plan.
-
-        Available options: `title`, `summary`, `content`.
       name: search_in
       in: query
       required: false
       schema:
-        type: string
-        default: title,content
-      examples:
-        single-field:
-          summary: Single field
-          value: title
-        multiple-fields:
-          summary: Multiple fields
-          value: title,content
+        $ref: "#/components/schemas/SearchIn"
+
+    IncludeTranslationFields:
+      name: include_translation_fields
+      in: query
+      required: false
+      schema:
+        $ref: "#/components/schemas/IncludeTranslationFields"
 
     Countries:
       description: |
@@ -2151,6 +2147,8 @@ components:
                 $ref: "#/components/schemas/Page"
               page_size:
                 $ref: "#/components/schemas/PageSize"
+              include_translation_fields:
+                $ref: "#/components/schemas/IncludeTranslationFields"
               include_nlp_data:
                 $ref: "#/components/schemas/IncludeNlpData"
               has_nlp:
@@ -2246,6 +2244,8 @@ components:
                 $ref: "#/components/schemas/ClusteringVariable"
               clustering_threshold:
                 $ref: "#/components/schemas/ClusteringThreshold"
+              include_translation_fields:
+                $ref: "#/components/schemas/IncludeTranslationFields"
               include_nlp_data:
                 $ref: "#/components/schemas/IncludeNlpData"
               has_nlp:
@@ -2312,6 +2312,8 @@ components:
                 $ref: "#/components/schemas/PageSize"
               top_n_articles:
                 $ref: "#/components/schemas/TopNArticles"
+              include_translation_fields:
+                $ref: "#/components/schemas/IncludeTranslationFields"
               include_nlp_data:
                 $ref: "#/components/schemas/IncludeNlpData"
               has_nlp:
@@ -2358,6 +2360,8 @@ components:
                 $ref: "#/components/schemas/Q"
               search_in:
                 $ref: "#/components/schemas/SearchIn"
+              include_translation_fields:
+                $ref: "#/components/schemas/IncludeTranslationFields"
               predefined_sources:
                 $ref: "#/components/schemas/PredefinedSources"
               source_name:
@@ -2540,6 +2544,8 @@ components:
                 $ref: "#/components/schemas/Q"
               search_in:
                 $ref: "#/components/schemas/SearchIn"
+              include_translation_fields:
+                $ref: "#/components/schemas/IncludeTranslationFields"
               include_similar_documents:
                 $ref: "#/components/schemas/IncludeSimilarDocuments"
               similar_documents_number:
@@ -3095,6 +3101,14 @@ components:
           title: Content
           description: The content of the article.
           type: string
+        title_translated_en:
+          type: string
+          description: |
+            English translation of the article title. Available when using the `search_in` parameter with the `title_translated` option or by setting the `include_translation_fields` parameter to `true`.
+        content_translated_en:
+          type: string
+          description: |
+            English translation of the article content. Available when using the `search_in` parameter with the `content_translated` option or by setting the `include_translation_fields` parameter to `true`.
         word_count:
           title: Word Count
           description: The word count of the article.
@@ -3156,6 +3170,10 @@ components:
       default: {}
       description: Natural Language Processing data for the article.
       properties:
+        translation_summary:
+          type: string
+          description: |
+            A brief AI-generated summary of the article's English translation.
         theme:
           type: string
           description: The themes or categories identified in the article.
@@ -3834,16 +3852,25 @@ components:
 
     SearchIn:
       type: string
-      default: title,content
+      default: title_content
       description: |
-        The article fields to search in. To search in multiple fields, use a comma-separated string. 
+        The article fields to search in. Use a comma-separated string for multiple options, with a maximum of 2 in a single request.
 
-        Example: `"title, summary"`
+        Available options: 
+        - Standard fields: `title`, `content`, `summary`, `title_content`
+        - Translation fields: `title_translated`, `content_translated`, `summary_translated`, `title_content_translated`
 
-        **Note**: The `summary` option is available if NLP is enabled in your plan.
+        **Note**: The summary and translation options are available only in NLP subscription plans.
+      example: title_content, title_content_translated
 
-        Available options: `title`, `summary`, `content`.
-      example: title,content
+    IncludeTranslationFields:
+      type: boolean
+      default: false
+      description: |
+        If true, the response includes translation fields `title_translated_en` and `content_translated_en`.
+
+        **Note**: Article translations are available only in the NLP plan.
+      example: true
 
     Countries:
       oneOf:

--- a/v3/documentation/get-started/news-api-v3-subscription-plans.mdx
+++ b/v3/documentation/get-started/news-api-v3-subscription-plans.mdx
@@ -41,6 +41,8 @@ description:
     <Check>Get AI-generated article summaries</Check>
     <Check>Enable article clustering with customizable thresholds</Check>
     <Check>Use content deduplication</Check>
+    <Check>Access English translations of non-English content</Check>
+    <Check>Search in English translations of articles</Check>
 
   </Tab>
   <Tab title="IPTC Tags">
@@ -73,24 +75,27 @@ description:
 
 ## Technical specifications
 
-| Feature                | Basic | NLP | IPTC Tags | Embeddings |
-| ---------------------- | ----- | --- | --------- | ---------- |
-| **Core Features**      |
-| All API Endpoints      | ✓     | ✓   | ✓         | ✓          |
-| 1000 Articles/Request  | ✓     | ✓   | ✓         | ✓          |
-| Source Classification  | ✓     | ✓   | ✓         | ✓          |
-| URL Filtering          | ✓     | ✓   | ✓         | ✓          |
-| Historical Data Access | ✓     | ✓   | ✓         | ✓          |
-| **NLP Features**       |
-| Theme Classification   | ✓     | ✓   | ✓         | ✓          |
-| Entity Recognition     | -     | ✓   | ✓         | ✓          |
-| Sentiment Analysis     | -     | ✓   | ✓         | ✓          |
-| Article Clustering     | -     | ✓   | ✓         | ✓          |
-| Content Deduplication  | -     | ✓   | ✓         | ✓          |
-| **Advanced Features**  |
-| IPTC Media Topics      | -     | -   | ✓         | ✓          |
-| IAB Categories         | -     | -   | ✓         | ✓          |
-| Vector Embeddings      | -     | -   | -         | ✓          |
+| Feature                  | Basic | NLP | IPTC Tags | Embeddings |
+| ------------------------ | ----- | --- | --------- | ---------- |
+| **Core Features**        |
+| All API Endpoints        | ✓     | ✓   | ✓         | ✓          |
+| 1000 Articles/Request    | ✓     | ✓   | ✓         | ✓          |
+| Source Classification    | ✓     | ✓   | ✓         | ✓          |
+| URL Filtering            | ✓     | ✓   | ✓         | ✓          |
+| Historical Data Access   | ✓     | ✓   | ✓         | ✓          |
+| **NLP Features**         |
+| Theme Classification     | ✓     | ✓   | ✓         | ✓          |
+| Entity Recognition       | -     | ✓   | ✓         | ✓          |
+| Sentiment Analysis       | -     | ✓   | ✓         | ✓          |
+| Article Clustering       | -     | ✓   | ✓         | ✓          |
+| Content Deduplication    | -     | ✓   | ✓         | ✓          |
+| **Translation Features** |
+| Content Translation      | -     | ✓   | ✓         | ✓          |
+| Search in Translations   | -     | ✓   | ✓         | ✓          |
+| **Advanced Features**    |
+| IPTC Media Topics        | -     | -   | ✓         | ✓          |
+| IAB Categories           | -     | -   | ✓         | ✓          |
+| Vector Embeddings        | -     | -   | -         | ✓          |
 
 ## Custom solutions
 

--- a/v3/documentation/guides-and-concepts/nlp-features.mdx
+++ b/v3/documentation/guides-and-concepts/nlp-features.mdx
@@ -25,6 +25,7 @@ The NLP layer in News API v3 consists of the following components:
 | Summary        | Concise overview of the article's content                                | v3_nlp            |
 | Sentiment      | Separate scores for title and content sentiment                          | v3_nlp            |
 | Named Entities | Identified persons, organizations, locations, and miscellaneous entities | v3_nlp            |
+| Translations   | English translations of non-English content (one-way only)               | v3_nlp            |
 | IPTC Tags      | Standardized news category tags                                          | v3_nlp_iptc_tags  |
 | IAB Tags       | Content categories for digital advertising                               | v3_nlp_iptc_tags  |
 | Custom Tags    | Organization-specific classification system                              | All v3 NLP plans  |
@@ -41,11 +42,14 @@ To control NLP data in your API responses, use the following parameters:
   article in response.
 - `has_nlp` (boolean): Set to `true` to filter the results to only articles with
   available NLP data.
+- `include_translation_fields` (boolean): Set to `true` to include translation
+  fields in the response.
 
 <Note>
   Some fields within the NLP object may be empty or `null` if specific analyses
   were not performed on the article. The full data is available for articles in
-  English and Arabic only.
+  English and Arabic only. Translation features are only available with the NLP
+  plan or higher.
 </Note>
 
 #### How these parameters work together
@@ -60,22 +64,26 @@ data:
   English and Arabic.
 - `include_nlp_data=false`: The NLP object is not included in the response,
   regardless of the `has_nlp` value.
+- `include_translation_fields=true`: Includes translation fields
+  (`title_translated_en` and `content_translated_en`) in the response.
 
 #### NLP coverage by language
 
 The table below shows which NLP features are available for different language
 categories:
 
-| Feature                  | English & Arabic | Other Languages | Coverage                           |
-| ------------------------ | ---------------- | --------------- | ---------------------------------- |
-| Theme classification     | ✓                | ✓ (limited)     | 10% of non-English/Arabic articles |
-| Summary                  | ✓                | ✓ (limited)     | 10% of non-English/Arabic articles |
-| Sentiment analysis       | ✓                | ✗               | 100% of English/Arabic articles    |
-| Named entity recognition | ✓                | ✗               | 100% of English/Arabic articles    |
-| Content tags             | ✓                | ✓ (limited)     | 10% of non-English/Arabic articles |
-| Vector embeddings        | ✓                | ✓               | Nearly 100% of all articles        |
-| Clustering               | ✓                | ✓               | All articles                       |
-| Deduplication            | ✓                | ✓               | All articles                       |
+| Feature                          | English & Arabic | Other Languages | Coverage                           |
+| -------------------------------- | ---------------- | --------------- | ---------------------------------- |
+| Theme classification             | ✓                | ✓ (limited)     | 10% of non-English/Arabic articles |
+| Summary                          | ✓                | ✓ (limited)     | 10% of non-English/Arabic articles |
+| Sentiment analysis               | ✓                | ✗               | 100% of English/Arabic articles    |
+| Named entity recognition         | ✓                | ✗               | 100% of English/Arabic articles    |
+| Content tags                     | ✓                | ✓ (limited)     | 10% of non-English/Arabic articles |
+| Vector embeddings                | ✓                | ✓               | Nearly 100% of all articles        |
+| Clustering                       | ✓                | ✓               | All articles                       |
+| Deduplication                    | ✓                | ✓               | All articles                       |
+| Translations to English          | ✗                | ✓               | All non-English articles           |
+| Search with English translations | ✗                | ✓               | All non-English articles           |
 
 For a complete list of supported languages, see
 [language codes in News API v3](/v3/api-reference/overview/enumerated-parameters#language-lang-and-not-lang).
@@ -363,6 +371,79 @@ Microsoft as organizations and Tim Cook or Satya Nadella as persons.
 
 To learn more about NER, see
 [How to search by entity](/v3/documentation/how-to/search-by-entity).
+
+## Translation features
+
+We translate and index all non-English articles to English, enabling you to
+search multilingual content using English keywords. This feature is available in
+the NLP plan and higher.
+
+### Available translation fields
+
+When using translation features, the API can include these fields in responses:
+
+- `title_translated_en`: English translation of the article title
+- `content_translated_en`: English translation of the article content
+- `nlp.translation_summary`: Brief AI-generated summary of the English
+  translation
+
+### Searching in translated content
+
+You can use English keywords to find relevant content in non-English articles by
+using the `search_in` parameter with these options:
+
+- `title_translated`: Search in English translations of titles.
+- `content_translated`: Search in English translations of content.
+- `summary_translated`: Search in summaries of English translations.
+- `title_content_translated`: Search in both English translated titles and
+  content.
+
+Example query:
+
+```json
+{
+  "q": "artificial intelligence",
+  "search_in": "title_content_translated",
+  "lang": "fr"
+}
+```
+
+This searches in English translations of French articles.
+
+### Retrieving translations
+
+To include translations in responses without searching them, use:
+
+```json
+{
+  "q": "économie",
+  "search_in": "title,content",
+  "lang": "fr",
+  "include_translation_fields": true
+}
+```
+
+### Example response with translations
+
+```json
+{
+  "articles": [
+    {
+      "title": "Royal London AM s'adosse à un TPM sur le marché espagnol",
+      "content": "Laurence Marchal\nLa société de gestion américaine TCW...",
+      "title_translated_en": "Royal London AM relies on a TPM on the Spanish market",
+      "content_translated_en": "Laurence Marchal\nThe American management company TCW...",
+      "language": "fr",
+      "nlp": {
+        "translation_summary": "TCW has signed an agreement with Fineco for distribution of an artificial intelligence equity fund..."
+      }
+    }
+  ]
+}
+```
+
+To learn more, see
+[Search and retrieve translated content](/v3/documentation/how-to/searching-translated-content).
 
 ## Tagging
 

--- a/v3/documentation/how-to/work-with-translations.mdx
+++ b/v3/documentation/how-to/work-with-translations.mdx
@@ -1,0 +1,244 @@
+---
+title: Search and retrieve translated content
+sidebarTitle: Work with translations
+description:
+  Learn how to search within translated articles and retrieve translated content
+  from News API v3
+---
+
+## Overview
+
+News API v3 provides translation capabilities that allow you to search across
+language barriers and retrieve translated content. This guide explains how to
+use these features to work with multilingual news content effectively.
+
+## Prerequisites
+
+- An active subscription with the **NLP plan** or higher
+- A valid API key with appropriate permissions
+
+## Key translation features
+
+News API v3 offers two main translation capabilities:
+
+1. **Search in translated content**: Find articles using English keywords even
+   when the original content is in another language.
+2. **Retrieve translated fields**: Include English translations in API
+   responses.
+
+## Searching in translated content
+
+To search within translated content, use the `search_in` parameter with one of
+these translation options:
+
+| Option                     | Description                                  |
+| -------------------------- | -------------------------------------------- |
+| `title_translated`         | Search only in translated titles             |
+| `content_translated`       | Search only in translated content            |
+| `summary_translated`       | Search only in translated summaries          |
+| `title_content_translated` | Search in both translated titles and content |
+
+**Example request:**
+
+<CodeGroup>
+```json JSON
+{
+  "q": "artificial intelligence",
+  "search_in": "title_content_translated",
+  "lang": "fr"
+}
+```
+
+```python Python
+import requests
+import json
+
+API_KEY = "YOUR_API_KEY"
+URL = "https://v3-api.newscatcherapi.com/api/search"
+HEADERS = {"x-api-token": API_KEY, "Content-Type": "application/json"}
+
+payload = {
+    "q": "artificial intelligence",
+    "search_in": "title_content_translated",
+    "lang": "fr"
+}
+
+try:
+    response = requests.post(URL, headers=HEADERS, json=payload)
+    response.raise_for_status()
+    print(json.dumps(response.json(), indent=2))
+except requests.exceptions.RequestException as e:
+    print(f"Failed to fetch articles: {e}")
+```
+
+```bash cURL
+curl -X POST "https://v3-api.newscatcherapi.com/api/search" \
+  -H "x-api-token: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "q": "artificial intelligence",
+    "search_in": "title_content_translated",
+    "lang": "fr"
+  }'
+```
+
+</CodeGroup>
+
+This request finds French articles where the English translation contains
+"artificial intelligence".
+
+## Retrieving translations
+
+When using the `search_in` parameter with translation options, translation
+fields are included in the response by default. To always include them, use the
+`include_translation_fields` parameter:
+
+<CodeGroup>
+```json JSON
+{
+  "q": "économie",
+  "search_in": "title,content",
+  "lang": "fr",
+  "include_translation_fields": true
+}
+```
+
+```python Python
+import requests
+import json
+
+API_KEY = "YOUR_API_KEY"
+URL = "https://v3-api.newscatcherapi.com/api/search"
+HEADERS = {"x-api-token": API_KEY, "Content-Type": "application/json"}
+
+payload = {
+    "q": "économie",
+    "search_in": "title,content",
+    "lang": "fr",
+    "include_translation_fields": true
+}
+
+try:
+    response = requests.post(URL, headers=HEADERS, json=payload)
+    response.raise_for_status()
+    print(json.dumps(response.json(), indent=2))
+except requests.exceptions.RequestException as e:
+    print(f"Failed to fetch articles: {e}")
+```
+
+```bash cURL
+curl -X POST "https://v3-api.newscatcherapi.com/api/search" \
+  -H "x-api-token: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "q": "économie",
+    "search_in": "title,content",
+    "lang": "fr",
+    "include_translation_fields": true
+  }'
+```
+
+</CodeGroup>
+
+## Combining original and translated search
+
+For comprehensive results, you can search in both original and translated fields
+simultaneously:
+
+<CodeGroup>
+```json JSON
+{
+  "q": "\"erneuerbare Energien\" OR  \"renewable energy\"",
+  "search_in": "title_content,title_content_translated",
+  "lang": "de"
+}
+```
+
+```python Python
+import requests
+import json
+
+API_KEY = "YOUR_API_KEY"
+URL = "https://v3-api.newscatcherapi.com/api/search"
+HEADERS = {"x-api-token": API_KEY, "Content-Type": "application/json"}
+
+payload = {
+    "q": "\"erneuerbare Energien\" OR  \"renewable energy\"",
+    "search_in": "title_content,title_content_translated",
+    "lang": "de"
+}
+
+try:
+    response = requests.post(URL, headers=HEADERS, json=payload)
+    response.raise_for_status()
+    print(json.dumps(response.json(), indent=2))
+except requests.exceptions.RequestException as e:
+    print(f"Failed to fetch articles: {e}")
+```
+
+```bash cURL
+curl -X POST "https://v3-api.newscatcherapi.com/api/search" \
+  -H "x-api-token: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "q": "\"erneuerbare Energien\" OR  \"renewable energy\"",
+    "search_in": "title_content,title_content_translated",
+    "lang": "de"
+  }'
+```
+
+</CodeGroup>
+
+<Warning>
+  You can specify a maximum of 2 options in the `search_in` parameter.
+</Warning>
+
+## Translation fields in responses
+
+When using translation features, these fields appear in responses:
+
+- `title_translated_en`: English translation of the article title
+- `content_translated_en`: English translation of the article content
+- `nlp.translation_summary`: Brief AI-generated summary of the translation (when
+  `include_nlp_data` is `true`)
+
+## Example response snippet
+
+```json Response {6-7, 10}
+{
+  "articles": [
+    {
+      "title": "Royal London AM s'adosse à un TPM sur le marché espagnol",
+      "content": "Laurence Marchal\nLa société de gestion américaine TCW...",
+      "title_translated_en": "Royal London AM relies on a TPM on the Spanish market",
+      "content_translated_en": "Laurence Marchal\nThe American management company TCW...",
+      "language": "fr",
+      "nlp": {
+        "translation_summary": "TCW has signed an agreement with Fineco for distribution of an artificial intelligence equity fund and a multi-asset class fund."
+      }
+    }
+  ]
+}
+```
+
+## Best practices
+
+1. **Use precise queries**: Translations may not capture all language nuances
+2. **Combine with filters**: Use `lang` and `countries` parameters to target
+   specific regions
+3. **Remember the 2-option limit**: The `search_in` parameter accepts a maximum
+   of 2 options
+
+## Limitations
+
+- Search in translations is only available for English translations
+- Translation features require the NLP subscription plan or higher
+- Translation quality varies by source language and content complexity
+- Translation search is only available for content from March 12, 2025 onwards,
+  as this is when the translation indexing was implemented
+
+## Related resources
+
+- [NLP features](/v3/documentation/guides-and-concepts/nlp-features)
+- [Advanced querying techniques](/v3/documentation/guides-and-concepts/advanced-querying)
+- [API Reference](/v3/api-reference/endpoints/search/search-articles-get)


### PR DESCRIPTION
## Description
This PR adds comprehensive documentation for the new translation features in News API v3. The implementation allows users to search in translated content and retrieve English translations of non-English articles.

## Changes
- Update the OpenAPI specification to include translation-related parameters and response fields for all schemas and components.
- Added new guide: "Search and retrieve translated content," which explains how to use translation features.
- Updated subscription plans documentation to incorporate translation capabilities in NLP plans.
- Enhanced NLP features documentation with detailed information about translations.
- Added cross-references between related documentation.

## Testing
- Verified that all updated documents are rendered correctly in the Mintlify preview.  
- Confirmed that all code examples work with the API.  
- Checked the links between related documents.

## Related Issues
Closes #86cyre279: [Docs | v3 | Document search in translations](https://app.clickup.com/t/86cyre279)