### PR TITLE
Rename "translation_summary" to "summary_translated"

### DIFF
--- a/v3/api-reference/news-api-v3.yml
+++ b/v3/api-reference/news-api-v3.yml
@@ -3170,7 +3170,7 @@ components:
       default: {}
       description: Natural Language Processing data for the article.
       properties:
-        translation_summary:
+        summary_translated:
           type: string
           description: |
             A brief AI-generated summary of the article's English translation.

--- a/v3/documentation/guides-and-concepts/nlp-features.mdx
+++ b/v3/documentation/guides-and-concepts/nlp-features.mdx
@@ -384,7 +384,7 @@ When using translation features, the API can include these fields in responses:
 
 - `title_translated_en`: English translation of the article title
 - `content_translated_en`: English translation of the article content
-- `nlp.translation_summary`: Brief AI-generated summary of the English
+- `nlp.summary_translated`: Brief AI-generated summary of the English
   translation
 
 ### Searching in translated content
@@ -435,7 +435,7 @@ To include translations in responses without searching them, use:
       "content_translated_en": "Laurence Marchal\nThe American management company TCW...",
       "language": "fr",
       "nlp": {
-        "translation_summary": "TCW has signed an agreement with Fineco for distribution of an artificial intelligence equity fund..."
+        "summary_translated": "TCW has signed an agreement with Fineco for distribution of an artificial intelligence equity fund..."
       }
     }
   ]

--- a/v3/documentation/how-to/work-with-translations.mdx
+++ b/v3/documentation/how-to/work-with-translations.mdx
@@ -199,7 +199,7 @@ When using translation features, these fields appear in responses:
 
 - `title_translated_en`: English translation of the article title
 - `content_translated_en`: English translation of the article content
-- `nlp.translation_summary`: Brief AI-generated summary of the translation (when
+- `nlp.summary_translated`: Brief AI-generated summary of the translation (when
   `include_nlp_data` is `true`)
 
 ## Example response snippet
@@ -214,7 +214,7 @@ When using translation features, these fields appear in responses:
       "content_translated_en": "Laurence Marchal\nThe American management company TCW...",
       "language": "fr",
       "nlp": {
-        "translation_summary": "TCW has signed an agreement with Fineco for distribution of an artificial intelligence equity fund and a multi-asset class fund."
+        "summary_translated": "TCW has signed an agreement with Fineco for distribution of an artificial intelligence equity fund and a multi-asset class fund."
       }
     }
   ]


### PR DESCRIPTION
Quick fix: Rename the "translation_summary" to "summary_translated" for consistency (as was agreed).