### PR TITLE
Document robots.txt compliance feature

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -95,7 +95,8 @@
         "v3/documentation/guides-and-concepts/nlp-features",
         "v3/documentation/guides-and-concepts/custom-tags",
         "v3/documentation/guides-and-concepts/entity-disambiguation",
-        "v3/documentation/guides-and-concepts/breaking-news"
+        "v3/documentation/guides-and-concepts/breaking-news",
+        "v3/documentation/guides-and-concepts/robots-txt-compliance"
       ]
     },
     {

--- a/v3/api-reference/news-api-v3.yml
+++ b/v3/api-reference/news-api-v3.yml
@@ -678,7 +678,6 @@ paths:
         - $ref: "#/components/parameters/NewsType"
         - $ref: "#/components/parameters/FromRank"
         - $ref: "#/components/parameters/ToRank"
-        - $ref: "#/components/parameters/RobotsCompliant"
       responses:
         "200":
           $ref: "#/components/responses/SourcesResponse"
@@ -2695,8 +2694,6 @@ components:
                 $ref: "#/components/schemas/FromRank"
               to_rank:
                 $ref: "#/components/schemas/ToRank"
-              robots_compliant:
-                $ref: "#/components/schemas/RobotsCompliant"
             example:
               predefined_sources:
                 - top 50 US
@@ -3775,11 +3772,6 @@ components:
           title: News Type
           description: The category of news provided by the source.
           type: string
-        robots_compliant:
-          title: Robots Compliant
-          description: |
-            True if the source allows automated access according to its robots.txt file; false otherwise.
-          type: boolean
       example:
         nb_articles_for_7d: 153
         country: "US"

--- a/v3/api-reference/news-api-v3.yml
+++ b/v3/api-reference/news-api-v3.yml
@@ -148,6 +148,7 @@ paths:
         - $ref: "#/components/parameters/NotIabTags"
         - $ref: "#/components/parameters/CustomTags"
         - $ref: "#/components/parameters/ExcludeDuplicates"
+        - $ref: "#/components/parameters/RobotsCompliant"
       responses:
         "200":
           $ref: "#/components/responses/SearchResponse"
@@ -246,6 +247,7 @@ paths:
         - $ref: "#/components/parameters/IabTags"
         - $ref: "#/components/parameters/NotIabTags"
         - $ref: "#/components/parameters/CustomTags"
+        - $ref: "#/components/parameters/RobotsCompliant"
       responses:
         "200":
           $ref: "#/components/responses/SearchResponse"
@@ -321,6 +323,7 @@ paths:
         - $ref: "#/components/parameters/TitleSentimentMax"
         - $ref: "#/components/parameters/ContentSentimentMin"
         - $ref: "#/components/parameters/ContentSentimentMax"
+        - $ref: "#/components/parameters/RobotsCompliant"
       responses:
         "200":
           $ref: "#/components/responses/BreakingNewsResponse"
@@ -419,6 +422,7 @@ paths:
         - $ref: "#/components/parameters/IabTags"
         - $ref: "#/components/parameters/NotIabTags"
         - $ref: "#/components/parameters/CustomTags"
+        - $ref: "#/components/parameters/RobotsCompliant"
       responses:
         "200":
           $ref: "#/components/responses/AuthorsResponse"
@@ -510,6 +514,7 @@ paths:
               - English phrases: `1 day ago`, `today`
         - $ref: "#/components/parameters/Page"
         - $ref: "#/components/parameters/PageSize"
+        - $ref: "#/components/parameters/RobotsCompliant"
       responses:
         "200":
           $ref: "#/components/responses/SearchLinkResponse"
@@ -605,6 +610,7 @@ paths:
         - $ref: "#/components/parameters/IptcTags"
         - $ref: "#/components/parameters/NotIptcTags"
         - $ref: "#/components/parameters/CustomTags"
+        - $ref: "#/components/parameters/RobotsCompliant"
       responses:
         "200":
           $ref: "#/components/responses/SearchSimilarResponse"
@@ -672,6 +678,7 @@ paths:
         - $ref: "#/components/parameters/NewsType"
         - $ref: "#/components/parameters/FromRank"
         - $ref: "#/components/parameters/ToRank"
+        - $ref: "#/components/parameters/RobotsCompliant"
       responses:
         "200":
           $ref: "#/components/responses/SourcesResponse"
@@ -772,6 +779,7 @@ paths:
         - $ref: "#/components/parameters/IptcTags"
         - $ref: "#/components/parameters/NotIptcTags"
         - $ref: "#/components/parameters/AggregationBy"
+        - $ref: "#/components/parameters/RobotsCompliant"
       responses:
         "200":
           $ref: "#/components/responses/AggregationCountResponse"
@@ -1975,6 +1983,16 @@ components:
         $ref: "#/components/schemas/TopNArticles"
       required: false
 
+    RobotsCompliant:
+      name: robots_compliant
+      in: query
+      required: false
+      schema:
+        type: boolean
+      description: |
+        If true, returns only articles/sources that comply with the publisher's robots.txt rules. If false, returns only articles/sources that do not comply with robots.txt rules. If omitted, returns all articles/sources regardless of compliance status.
+      example: true
+
   requestBodies:
     AggregationRequestBody:
       description:
@@ -2074,6 +2092,8 @@ components:
                 $ref: "#/components/schemas/NotIptcTags"
               aggregation_by:
                 $ref: "#/components/schemas/AggregationBy"
+              robots_compliant:
+                $ref: "#/components/schemas/RobotsCompliant"
             example:
               q: renewable energy
               predefined_sources: top 50 US
@@ -2177,6 +2197,8 @@ components:
                 $ref: "#/components/schemas/NotIabTags"
               custom_tags:
                 $ref: "#/components/schemas/CustomTags"
+              robots_compliant:
+                $ref: "#/components/schemas/RobotsCompliant"
             example:
               author_name: Joanna Stern
               lang: en
@@ -2280,6 +2302,8 @@ components:
                 $ref: "#/components/schemas/NotIabTags"
               custom_tags:
                 $ref: "#/components/schemas/CustomTags"
+              robots_compliant:
+                $ref: "#/components/schemas/RobotsCompliant"
             example:
               lang: en
               predefined_sources:
@@ -2338,6 +2362,8 @@ components:
                 $ref: "#/components/schemas/ContentSentimentMin"
               content_sentient_max:
                 $ref: "#/components/schemas/ContentSentimentMax"
+              robots_compliant:
+                $ref: "#/components/schemas/RobotsCompliant"
             example:
               sort_by: relevancy
               page: 1
@@ -2466,6 +2492,8 @@ components:
                 $ref: "#/components/schemas/CustomTags"
               exclude_duplicates:
                 $ref: "#/components/schemas/ExcludeDuplicates"
+              robots_compliant:
+                $ref: "#/components/schemas/RobotsCompliant"
             example:
               q: renewable energy
               predefined_sources:
@@ -2520,6 +2548,8 @@ components:
                 $ref: "#/components/schemas/Page"
               page_size:
                 $ref: "#/components/schemas/PageSize"
+              robots_compliant:
+                $ref: "#/components/schemas/RobotsCompliant"
             example:
               ids:
                 - 8ea8a784568ffaa05cb6d1ab2d2e84dd
@@ -2626,6 +2656,8 @@ components:
                 $ref: "#/components/schemas/NotIptcTags"
               custom_tags:
                 $ref: "#/components/schemas/CustomTags"
+              robots_compliant:
+                $ref: "#/components/schemas/RobotsCompliant"
             example:
               q: artificial intelligence
               include_similar_documents: true
@@ -2663,6 +2695,8 @@ components:
                 $ref: "#/components/schemas/FromRank"
               to_rank:
                 $ref: "#/components/schemas/ToRank"
+              robots_compliant:
+                $ref: "#/components/schemas/RobotsCompliant"
             example:
               predefined_sources:
                 - top 50 US
@@ -3150,6 +3184,12 @@ components:
           title: Score
           description: The relevance score of the article.
           type: number
+        robots_compliant:
+          title: Robots Compliant
+          description: |
+            True if the article content can be safely accessed according to the publisher's robots.txt rules; false otherwise.
+          type: boolean
+          example: true
         custom_tags:
           title: Custom Tags
           description:
@@ -3597,6 +3637,12 @@ components:
           title: Score
           description: The relevance score of the article.
           type: number
+        robots_compliant:
+          title: Robots Compliant
+          description: |
+            True if the article content can be safely accessed according to the publisher's robots.txt rules; false otherwise.
+          type: boolean
+          example: true
 
     SimilarArticleEntity:
       title: Search Similar Article Object
@@ -3729,6 +3775,11 @@ components:
           title: News Type
           description: The category of news provided by the source.
           type: string
+        robots_compliant:
+          title: Robots Compliant
+          description: |
+            True if the source allows automated access according to its robots.txt file; false otherwise.
+          type: boolean
       example:
         nb_articles_for_7d: 153
         country: "US"
@@ -3736,6 +3787,7 @@ components:
         is_news_domain: true
         news_domain_type: "Original Content"
         news_type: "General News Outlets"
+        robots_compliant: true
 
     # Subscription related schema for the response object
     SubscriptionResponseDto:
@@ -4720,6 +4772,12 @@ components:
         - Maximum value is 100.
         - The product of `top_n_articles` x `page_size` must not exceed 1,000 (total articles limit).
       example: 5
+
+    RobotsCompliant:
+      type: boolean
+      description: |
+        If true, returns only articles/sources that comply with the publisher's robots.txt rules. If false, returns only articles/sources that do not comply with robots.txt rules. If omitted, returns all articles/sources regardless of compliance status.
+      example: true
 
   securitySchemes:
     ApiKeyAuth:

--- a/v3/documentation/get-started/news-api-v3-subscription-plans.mdx
+++ b/v3/documentation/get-started/news-api-v3-subscription-plans.mdx
@@ -27,6 +27,7 @@ description:
     <Check>Use URL and domain link filtering</Check>
     <Check>Access predefined top sources by country</Check>
     <Check>Filter by news domain type and source metadata</Check>
+    <Check>Filter by robots.txt compliance to ensure publisher permissions</Check>
     <Check>Access historical data since July 2023</Check>
 
   </Tab>
@@ -82,6 +83,7 @@ description:
 | 1000 Articles/Request    | ✓     | ✓   | ✓         | ✓          |
 | Source Classification    | ✓     | ✓   | ✓         | ✓          |
 | URL Filtering            | ✓     | ✓   | ✓         | ✓          |
+| Robots.txt compliance    | ✓     | ✓   | ✓         | ✓          |
 | Historical Data Access   | ✓     | ✓   | ✓         | ✓          |
 | **NLP Features**         |
 | Theme Classification     | ✓     | ✓   | ✓         | ✓          |

--- a/v3/documentation/guides-and-concepts/robots-txt-compliance.mdx
+++ b/v3/documentation/guides-and-concepts/robots-txt-compliance.mdx
@@ -6,16 +6,21 @@ description:
   applications that respect publisher permissions
 ---
 
-News API v3 includes robots.txt compliance information with every article and
-source, helping you build applications that respect publisher permissions. This
-feature provides transparency about whether content adheres to the source
-website's automated access guidelines.
+News API v3 includes robots.txt compliance information with every article,
+helping you build applications that respect publisher permissions. This feature
+provides transparency about whether content adheres to the source website's
+automated access guidelines.
 
 ## What is robots.txt compliance?
 
 Robots.txt files allow website publishers to specify which parts of their site
 can be accessed by automated tools. News API v3 respects these guidelines by
-marking each article and source with its compliance status.
+marking each article with its compliance status.
+
+<Note>
+  The robots.txt compliance check is performed at the time of article collection
+  and reflects the publisher's guidelines at that moment.
+</Note>
 
 ## The robots_compliant field
 
@@ -34,30 +39,10 @@ automated access is allowed; if false, it is restricted.
 }
 ```
 
-For the `/sources` endpoint, the compliance information appears in the
-`additional_info` object:
-
-```json {12}
-{
-  "name_source": "Yahoo",
-  "domain_url": "yahoo.com",
-  "logo": "https://all-logos-bucket.s3.amazonaws.com/yahoo.com.png",
-  "additional_info": {
-    "nb_articles_for_7d": 58306,
-    "country": "US",
-    "rank": 45,
-    "is_news_domain": false,
-    "news_domain_type": "Aggregator",
-    "news_type": "Corporate News",
-    "robots_compliant": true
-  }
-}
-```
-
 ## Filtering by compliance
 
 Use the optional `robots_compliant` parameter to filter your API requests. This
-parameter works with all endpoints that return articles or sources.
+parameter works with all endpoints that return articles.
 
 <Tabs>
   <Tab title="All articles">
@@ -85,15 +70,6 @@ parameter works with all endpoints that return articles or sources.
     }
     ```
     Returns only articles flagged as non-compliant.
-  </Tab>
-    <Tab title="All sources">
-    ```json
-    {
-      "countries": "US",
-      "include_additional_info": true
-    }
-    ```
-    Returns all sources with compliance status indicated (default behavior).
   </Tab>
 </Tabs>
 
@@ -142,5 +118,4 @@ parameter works with all endpoints that return articles or sources.
 ## See also
 
 - [API Reference](/v3/api-reference/endpoints/search/search-articles-get)
-- [Check sources coverage](/v3/documentation/how-to/check-sources-coverage)
 - [Error handling](/v3/documentation/troubleshooting/error-handling)

--- a/v3/documentation/guides-and-concepts/robots-txt-compliance.mdx
+++ b/v3/documentation/guides-and-concepts/robots-txt-compliance.mdx
@@ -1,0 +1,146 @@
+---
+title: Robots.txt compliance in News API v3
+sidebarTitle: Robots.txt compliance
+description:
+  Understand robots.txt compliance fields and parameters in News API v3 to build
+  applications that respect publisher permissions
+---
+
+News API v3 includes robots.txt compliance information with every article and
+source, helping you build applications that respect publisher permissions. This
+feature provides transparency about whether content adheres to the source
+website's automated access guidelines.
+
+## What is robots.txt compliance?
+
+Robots.txt files allow website publishers to specify which parts of their site
+can be accessed by automated tools. News API v3 respects these guidelines by
+marking each article and source with its compliance status.
+
+## The robots_compliant field
+
+Each API response includes a `robots_compliant` boolean field indicating if
+content can be safely accessed according to the publisher's guidelines. If true,
+automated access is allowed; if false, it is restricted.
+
+```json {6}
+{
+  "title": "Revolutionary AI Technology Breakthrough",
+  "author": "Jane Smith",
+  "domain_url": "techcrunch.com",
+  "content": "Scientists have made a groundbreaking discovery...",
+  "robots_compliant": true
+  // other article field
+}
+```
+
+For the `/sources` endpoint, the compliance information appears in the
+`additional_info` object:
+
+```json {12}
+{
+  "name_source": "Yahoo",
+  "domain_url": "yahoo.com",
+  "logo": "https://all-logos-bucket.s3.amazonaws.com/yahoo.com.png",
+  "additional_info": {
+    "nb_articles_for_7d": 58306,
+    "country": "US",
+    "rank": 45,
+    "is_news_domain": false,
+    "news_domain_type": "Aggregator",
+    "news_type": "Corporate News",
+    "robots_compliant": true
+  }
+}
+```
+
+## Filtering by compliance
+
+Use the optional `robots_compliant` parameter to filter your API requests. This
+parameter works with all endpoints that return articles or sources.
+
+<Tabs>
+  <Tab title="All articles">
+    ```json
+    {
+      "q": "artificial intelligence"
+    }
+    ```
+    If the parameter is ommited, the API returns all articles with compliance status indicated (default behavior).
+  </Tab>
+  <Tab title="Compliant only">
+    ```json
+    {
+      "q": "artificial intelligence",
+      "robots_compliant": true
+    }
+    ```
+    Returns only articles that comply with publisher guidelines.
+  </Tab>
+  <Tab title="Non-compliant only">
+    ```json
+    {
+      "q": "artificial intelligence",
+      "robots_compliant": false
+    }
+    ```
+    Returns only articles flagged as non-compliant.
+  </Tab>
+    <Tab title="All sources">
+    ```json
+    {
+      "countries": "US",
+      "include_additional_info": true
+    }
+    ```
+    Returns all sources with compliance status indicated (default behavior).
+  </Tab>
+</Tabs>
+
+## Benefits
+
+<CardGroup cols={2}>
+  <Card title="Legal compliance" icon="shield-check">
+    Reduce legal risks by respecting publisher-defined access policies and
+    maintaining good relationships with content providers.
+  </Card>
+  <Card title="Performance optimization" icon="gauge">
+    Filter non-compliant content server-side, reducing unnecessary data transfer
+    and improving application performance.
+  </Card>
+  <Card title="Publisher relations" icon="handshake">
+    Demonstrate respect for content providers' access policies, fostering better
+    long-term partnerships.
+  </Card>
+  <Card title="Transparency" icon="eye">
+    Clear visibility into which content can be safely used, enabling informed
+    decisions about content usage.
+  </Card>
+</CardGroup>
+
+## Implementation considerations
+
+<AccordionGroup>
+  <Accordion title="Always present in responses">
+    The `robots_compliant` field is included in every article object, ensuring
+    consistent access to compliance information regardless of filtering.
+  </Accordion>
+  <Accordion title="Optional parameter">
+    You can include the `robots_compliant` parameter in requests to filter
+    results, or omit it to receive all content with compliance flags.
+  </Accordion>
+  <Accordion title="Server-side filtering">
+    When you use the parameter, filtering happens at the API level, improving
+    performance by reducing unnecessary data transfer.
+  </Accordion>
+  <Accordion title="Boolean values only">
+    The parameter accepts `true` to show only compliant content, `false` for
+    non-compliant content, or can be omitted entirely.
+  </Accordion>
+</AccordionGroup>
+
+## See also
+
+- [API Reference](/v3/api-reference/endpoints/search/search-articles-get)
+- [Check sources coverage](/v3/documentation/how-to/check-sources-coverage)
+- [Error handling](/v3/documentation/troubleshooting/error-handling)


### PR DESCRIPTION
The PR adds the robots.txt compliance feature to the New API v3. The `robots_compliant` boolean field is included in article responses and aggregations, with an optional parameter for filtering by compliance status. This feature is available in all subscription plans.

## Key changes

- Add robots_compliant parameter and field to the OpenAPI specification for all the endpoints and related schemas.
- Add concept doc explaining robots.txt compliance field and filtering.
- Update subscription plans page to include robots.txt compliance feature.
- Add navigation entry for new documentation in guides and concepts in mint.json.

## Fixes

- Remove the feature from the `/sources` endpoint on the OpenAPI spec and documentation level, as it will be implemented later and possibly with another approach.

