### PR TITLE
Fix/v3 basic

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ curl -X GET "https://v3-api.newscatcherapi.com/api/search?q=artificial%20intelli
 ### API Support
 
 - **Customer Portal**: [support.newscatcherapi.com](https://support.newscatcherapi.com/customer-portal)
-- **Email**: <support@newscatcherapi.com>
+- **Email**: [support@newscatcherapi.com](mailto:support@newscatcherapi.com)
 - **Status Page**: [status.newscatcherapi.com](https://status.newscatcherapi.com)
 
 ## Resources

--- a/v3/documentation/get-started/news-api-v3-subscription-plans.mdx
+++ b/v3/documentation/get-started/news-api-v3-subscription-plans.mdx
@@ -1,9 +1,7 @@
 ---
 title: News API v3 subscription plans
 sidebarTitle: Subscription plans
-description:
-  Select a News API v3 plan that matches your needs - from basic news monitoring
-  to advanced AI-powered content analysis.
+description: Select a News API v3 plan that matches your needs
 ---
 
 <Note>
@@ -15,116 +13,93 @@ description:
 ## Available plans
 
 <Tabs>
-  <Tab title="Basic">
-    **Plan ID**: `v3_basic`
+ <Tab title="NLP" icon="brain">
+   **Plan ID**: `v3_nlp`
 
-    Entry-level plan with access to all core functionality:
+Core features plus natural language processing capabilities for original content
+and English translations.
 
-    <Check>Access all API endpoints with comprehensive metadata</Check>
-    <Check>Retrieve up to 1,000 articles per request</Check>
-    <Check>Categorize content across 17 themes (Business, Tech, Politics, and more)</Check>
-    <Check>Filter by article type (headline, opinion, paid content)</Check>
-    <Check>Use URL and domain link filtering</Check>
-    <Check>Access predefined top sources by country</Check>
-    <Check>Filter by news domain type and source metadata</Check>
-    <Check>Filter by robots.txt compliance to ensure publisher permissions</Check>
-    <Check>Access historical data since July 2023</Check>
+**Core features:**
 
-  </Tab>
-  <Tab title="NLP">
-    **Plan ID**: `v3_nlp`
+- Retrieve up to 1,000 articles per request
+- Filter by article type (headline, opinion, paid content)
+- URL and domain link filtering
+- Access predefined top sources by country
+- Filter by news domain type and source metadata
+- Filter by robots.txt compliance to ensure publisher permissions
+- Access historical data since 2019
 
-    Standard NLP plan adds comprehensive content analysis capabilities:
+**NLP features:**
 
-    <Check>Access all Basic plan features</Check>
-    <Check>Detect named entities (PER, ORG, LOC, MISC)</Check>
-    <Check>Analyze sentiment in titles and content on a `-1.0` to `1.0` scale</Check>
-    <Check>Get AI-generated article summaries</Check>
-    <Check>Enable article clustering with customizable thresholds</Check>
-    <Check>Use content deduplication</Check>
-    <Check>Access English translations of non-English content</Check>
-    <Check>Search in English translations of articles</Check>
+- Categorize content across 17 themes (`Business`, `Tech`, `Politics`, and more)
+- Detect named entities (`PER`, `ORG`, `LOC`, `MISC`)
+- Analyze sentiment in titles and content on a `-1.0` to `1.0` scale
+- Get AI-generated article summaries
+- Enable article clustering with customizable thresholds
+- Use content deduplication
+- Access English translations of non-English content
+- **Full NLP processing on translations:** All NLP features (sentiment,
+  entities, summaries) work on English translations of foreign content
 
-  </Tab>
-  <Tab title="IPTC Tags">
-    **Plan ID**: `v3_nlp_iptc_tags`
+ </Tab>
+ <Tab title="IPTC Tags" icon="tags">
+   **Plan ID**: `v3_nlp_iptc_tags`
 
-    IPTC Tags plan adds standardized content categorization:
+All NLP plan features plus standardized content categorization:
 
-    <Check>Access all NLP plan features</Check>
-    <Check>Use IPTC media topic tags for standardized news categorization</Check>
-    <Check>Access IAB content categories for digital advertising</Check>
-    <Check>Enable hierarchical topic structures</Check>
-    <Check>Implement industry-standard content taxonomy</Check>
-    <Check>Enhanced content targeting capabilities</Check>
+- Use `IPTC` media topic tags for standardized news categorization
+- Access `IAB` content categories for digital advertising
+- Enable hierarchical topic structures
+- Implement industry-standard content taxonomy
+- Enhanced content targeting capabilities
 
-  </Tab>
-  <Tab title="Embeddings">
-    **Plan ID**: `v3_nlp_embeddings`
+ </Tab>
+ <Tab title="Embeddings" icon="vector-square">
+   **Plan ID**: `v3_nlp_embeddings`
 
-    Embeddings plan adds vector embeddings for advanced analysis:
+All IPTC Tags plan features plus pre-calculated vector embeddings:
 
-    <Check>Access all IPTC Tags plan features</Check>
-    <Check>Get 1024-dimensional vector embeddings via `nlp.new_embeddings`</Check>
-    <Check>Use multilingual-e5-large model for embeddings</Check>
-    <Check>Enable semantic similarity comparison</Check>
-    <Check>Build advanced content clustering</Check>
-    <Check>Implement recommendation systems</Check>
+- Access 1024-dimensional vector embeddings via `nlp.new_embeddings` field
+- Embeddings generated using `multilingual-e5-large` model
+- Use embedding data to build semantic search and similarity analysis
+- Create custom content clustering and recommendation systems
 
-  </Tab>
+ </Tab>
 </Tabs>
-
-## Technical specifications
-
-| Feature                  | Basic | NLP | IPTC Tags | Embeddings |
-| ------------------------ | ----- | --- | --------- | ---------- |
-| **Core Features**        |
-| All API Endpoints        | ✓     | ✓   | ✓         | ✓          |
-| 1000 Articles/Request    | ✓     | ✓   | ✓         | ✓          |
-| Source Classification    | ✓     | ✓   | ✓         | ✓          |
-| URL Filtering            | ✓     | ✓   | ✓         | ✓          |
-| Robots.txt compliance    | ✓     | ✓   | ✓         | ✓          |
-| Historical Data Access   | ✓     | ✓   | ✓         | ✓          |
-| **NLP Features**         |
-| Theme Classification     | ✓     | ✓   | ✓         | ✓          |
-| Entity Recognition       | -     | ✓   | ✓         | ✓          |
-| Sentiment Analysis       | -     | ✓   | ✓         | ✓          |
-| Article Clustering       | -     | ✓   | ✓         | ✓          |
-| Content Deduplication    | -     | ✓   | ✓         | ✓          |
-| **Translation Features** |
-| Content Translation      | -     | ✓   | ✓         | ✓          |
-| Search in Translations   | -     | ✓   | ✓         | ✓          |
-| **Advanced Features**    |
-| IPTC Media Topics        | -     | -   | ✓         | ✓          |
-| IAB Categories           | -     | -   | ✓         | ✓          |
-| Vector Embeddings        | -     | -   | -         | ✓          |
-
-## Custom solutions
-
-Beyond our standard plans, we offer specialized enterprise solutions:
-
-- **Custom Tags**: Implement organization-specific taxonomy for content
-  classification.
-- **Entity Resolution**: Cut through multiple mentions of similarly-named
-  companies and individuals by resolving unique identifiers and providing
-  precise entity matching.
-- **Events Intelligence**: Track, deduplicate, and analyze events across
-  multiple sources while extracting standardized information about participants,
-  locations, and timelines.
-- **Insights Engine**: Identify market opportunities through tracking product
-  releases and industry trends.
 
 <Warning>
   To ensure uninterrupted service, implement appropriate rate limiting in your
   application based on your plan's specifications.
 </Warning>
 
+## Custom solutions
+
+Beyond our standard plans, we offer specialized enterprise solutions:
+
+<Columns cols={2}>
+  <Card title="Events Intelligence" icon="calendar-check">
+    Track and analyze events across multiple sources with standardized
+    participant and location data
+  </Card>
+  <Card title="Entity Resolution" icon="users">
+    Resolve unique identifiers for similarly-named companies and individuals
+    with precise entity matching
+  </Card>
+  <Card title="Custom Tags" icon="tag">
+    Implement organization-specific taxonomy for content classification
+  </Card>
+  <Card title="Insights Engine" icon="lightbulb">
+    Identify market opportunities through tracking product releases and industry
+    trends
+  </Card>
+</Columns>
+
 ## Next steps
 
 1. Review feature documentation:
    - [NLP features](/v3/documentation/guides-and-concepts/nlp-features)
-   - [Clustering](/v3/documentation/guides-and-concepts/clustering-news-articles)
-   - [Custom tagging](/v3/documentation/guides-and-concepts/custom-tagging)
+   - [Search in translations](/v3/documentation/how-to/seach-in-translations)
+   - [Working with historical data](/v3/documentation/guides-and-concepts/working-with-historical-data)
 2. Explore the [API Reference](/v3/api-reference)
 3. Visit the [pricing page](https://www.newscatcherapi.com/pricing) to start
    your subscription

--- a/v3/documentation/migration/api-changes-v2-vs-v3.mdx
+++ b/v3/documentation/migration/api-changes-v2-vs-v3.mdx
@@ -109,7 +109,7 @@ For detailed plan information, see
 
 ### Core features
 
-Available in all v3 plans, including `v3_basic`.
+The following features are available in all v3 plans.
 
 #### Content classification
 
@@ -414,8 +414,7 @@ implementation details, see the
 ### Support during migration
 
 - Both versions are available for parallel testing.
-- Automatic migration to `v3_basic` plan for existing v2 customers.
-- All new v3 endpoints accessible in `v3_basic` plan.
+- All News API v3 endpoints accessible for existing v2 customers.
 - Advanced features require specific plans:
   - NLP features: `v3_nlp` plan.
   - IPTC and IAB tags: `v3_nlp_iptc_tags` plan.


### PR DESCRIPTION
Remove mentioning of the deprecated v3_basic plan.

## Changes

- Remove v3_basic and refactor the subscription plans page
- Remove v3_basic from v2-v3 migration page
- Fix email formatting in README to follow Mintlify engine validation rules