### PR TITLE
Add CatchAll API documentation (beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,31 @@
 
 [![Documentation Status](https://img.shields.io/website?url=https%3A%2F%2Fwww.newscatcherapi.com%2Fdocs)](https://www.newscatcherapi.com/docs)
 
-Documentation repository for the NewsCatcher API, built with [Mintlify](https://mintlify.com/) and hosted at [newscatcherapi.com/docs](https://www.newscatcherapi.com/docs).
+Documentation repository for the NewsCatcher API, built with
+[Mintlify](https://mintlify.com/) and hosted at
+[newscatcherapi.com/docs](https://www.newscatcherapi.com/docs).
 
 ## Table of Contents
 
 1. [About](#about)
-2. [Repository Structure](#repository-structure)  
+2. [Repository Structure](#repository-structure)
 3. [Getting Started](#getting-started)
 4. [Contributing](#contributing)
 5. [Support](#support)
 
 ## About
 
-NewsCatcher API provides access to news articles from over 90,000 sources worldwide with three main public APIs:
+NewsCatcher API provides access to news articles from over 90,000 sources
+worldwide with three main public APIs:
 
-- **News API v3**: Search and retrieve news articles with metadata enrichment and NLP.
+- **News API v3**: Search and retrieve news articles with metadata enrichment
+  and NLP.
 - **Local News API**: Hyper local news with geographic detection and NLP.
-- **Events API**: Structured event data (data breaches, fundraising, layoffs, supply chain disruptions, tariffs, etc.)
+- **Events API**: Structured event data (data breaches, fundraising, layoffs,
+  supply chain disruptions, tariffs, etc.)
 
-NLP featues include summarisation, topic modeling, sentiment analysis, entity recognition, clustering, and deduplication.
+NLP featues include summarisation, topic modeling, sentiment analysis, entity
+recognition, clustering, and deduplication.
 
 ## Repository Structure
 
@@ -74,7 +80,8 @@ curl -X GET "https://v3-api.newscatcherapi.com/api/search?q=artificial%20intelli
 ### Documentation Updates
 
 1. Create a new branch: `git checkout -b docs/your-change`
-2. Make changes following the [Google Developer Documentation Style Guide](https://developers.google.com/style)
+2. Make changes following the
+   [Google Developer Documentation Style Guide](https://developers.google.com/style)
 3. Test locally: `mint dev`
 4. Submit a pull request
 
@@ -89,15 +96,16 @@ curl -X GET "https://v3-api.newscatcherapi.com/api/search?q=artificial%20intelli
 
 1. Update navigation in `docs.json`
 2. Create MDX files in appropriate directories
-3. For each MDX file, include proper frontmatter (title, sidebarTitle, description)
+3. For each MDX file, include proper frontmatter (title, sidebarTitle,
+   description)
 
 ### Common Issues
 
-| Issue | Solution |
-|-------|----------|
-| `mint dev` not found | Install globally: `npm i -g mint` |
-| Port 3000 in use | Use different port: `mint dev --port 3001` |
-| Python script errors | Ensure Python 3.10+ is installed |
+| Issue                | Solution                                   |
+| -------------------- | ------------------------------------------ |
+| `mint dev` not found | Install globally: `npm i -g mint`          |
+| Port 3000 in use     | Use different port: `mint dev --port 3001` |
+| Python script errors | Ensure Python 3.10+ is installed           |
 
 ## Support
 
@@ -108,15 +116,17 @@ curl -X GET "https://v3-api.newscatcherapi.com/api/search?q=artificial%20intelli
 
 ### API Support
 
-- **Customer Portal**: [support.newscatcherapi.com](https://support.newscatcherapi.com/customer-portal)
+- **Customer Portal**:
+  [support.newscatcherapi.com](https://support.newscatcherapi.com/customer-portal)
 - **Email**: [support@newscatcherapi.com](mailto:support@newscatcherapi.com)
-- **Status Page**: [status.newscatcherapi.com](https://status.newscatcherapi.com)
+- **Status Page**:
+  [status.newscatcherapi.com](https://status.newscatcherapi.com)
 
 ## Resources
 
-- [NewsCatcher API Homepage](https://www.newscatcherapi.com)
-- [API Pricing](https://www.newscatcherapi.com/pricing)
-- [Postman Collections](https://www.postman.com/newscatcherapi/newscatcher-public-workspace/overview)
+- [NewsCatcher API homepage](https://www.newscatcherapi.com)
+- [Book a demo](https://www.newscatcherapi.com/book-a-demo)
+- [Postman collections](https://www.postman.com/newscatcherapi/newscatcher-public-workspace/overview)
 
 ---
 

--- a/change_links.py
+++ b/change_links.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Script to find and replace outdated links in MDX and YAML files.
+"""
+
+import os
+import re
+from pathlib import Path
+from typing import List, Tuple
+
+# Configuration
+OLD_LINK = "https://www.newscatcherapi.com/pricing"
+NEW_LINK = "https://www.newscatcherapi.com/book-a-demo"
+FILE_EXTENSIONS = [".md", ".mdx", ".yml", ".yaml"]
+
+
+def find_files(root_dir: str, extensions: List[str]) -> List[Path]:
+    """Find all files with specified extensions in directory tree."""
+    files = []
+    for ext in extensions:
+        files.extend(Path(root_dir).rglob(f"*{ext}"))
+    return files
+
+
+def replace_links_in_file(
+    file_path: Path, old_link: str, new_link: str, dry_run: bool = True
+) -> Tuple[bool, int]:
+    """
+    Replace old link with new link in a file.
+
+    Returns:
+        Tuple of (file_modified, occurrences_found)
+    """
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Count occurrences
+        occurrences = content.count(old_link)
+
+        if occurrences == 0:
+            return False, 0
+
+        # Replace the link
+        new_content = content.replace(old_link, new_link)
+
+        if not dry_run:
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(new_content)
+
+        return True, occurrences
+
+    except Exception as e:
+        print(f"Error processing {file_path}: {e}")
+        return False, 0
+
+
+def main():
+    # Get repository root directory
+    repo_path = input(
+        "Enter the path to your repository (or '.' for current directory): "
+    ).strip()
+    if not repo_path:
+        repo_path = "."
+
+    repo_path = os.path.abspath(repo_path)
+
+    if not os.path.exists(repo_path):
+        print(f"Error: Directory '{repo_path}' does not exist.")
+        return
+
+    print(f"\nScanning repository: {repo_path}")
+    print(f"Looking for: {OLD_LINK}")
+    print(f"Will replace with: {NEW_LINK}")
+    print(f"File types: {', '.join(FILE_EXTENSIONS)}\n")
+
+    # Find all relevant files
+    print("Finding files...")
+    files = find_files(repo_path, FILE_EXTENSIONS)
+    print(f"Found {len(files)} files to scan.\n")
+
+    # Dry run first
+    print("=" * 70)
+    print("DRY RUN - No files will be modified yet")
+    print("=" * 70)
+
+    modified_files = []
+    total_occurrences = 0
+
+    for file_path in files:
+        modified, occurrences = replace_links_in_file(
+            file_path, OLD_LINK, NEW_LINK, dry_run=True
+        )
+        if modified:
+            modified_files.append((file_path, occurrences))
+            total_occurrences += occurrences
+            rel_path = file_path.relative_to(repo_path)
+            print(f"✓ {rel_path} - {occurrences} occurrence(s)")
+
+    print("\n" + "=" * 70)
+    print(
+        f"Summary: Found {total_occurrences} occurrence(s) in {len(modified_files)} file(s)"
+    )
+    print("=" * 70)
+
+    if not modified_files:
+        print("\nNo links found to replace. Exiting.")
+        return
+
+    # Ask for confirmation
+    response = input("\nProceed with replacement? (yes/no): ").strip().lower()
+
+    if response not in ["yes", "y"]:
+        print("Operation cancelled.")
+        return
+
+    # Actual replacement
+    print("\n" + "=" * 70)
+    print("REPLACING LINKS")
+    print("=" * 70)
+
+    success_count = 0
+    for file_path, _ in modified_files:
+        modified, occurrences = replace_links_in_file(
+            file_path, OLD_LINK, NEW_LINK, dry_run=False
+        )
+        if modified:
+            success_count += 1
+            rel_path = file_path.relative_to(repo_path)
+            print(f"✓ Updated {rel_path}")
+
+    print("\n" + "=" * 70)
+    print(f"✓ Successfully updated {success_count} file(s)!")
+    print("=" * 70)
+    print("\nDon't forget to:")
+    print("1. Review the changes with 'git diff'")
+    print("2. Test your documentation")
+    print("3. Commit the changes")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs.json
+++ b/docs.json
@@ -257,7 +257,7 @@
             ]
           },
           {
-            "tab": "Catch All (Beta)",
+            "tab": "CatchAll (Beta)",
             "groups": [
               {
                 "group": "Overview",

--- a/docs.json
+++ b/docs.json
@@ -255,6 +255,27 @@
                 ]
               }
             ]
+          },
+          {
+            "tab": "Catch All (Beta)",
+            "groups": [
+              {
+                "group": "Overview",
+                "pages": [
+                  "v3/catch-all/overview/introduction",
+                  "v3/catch-all/overview/quickstart",
+                  "v3/catch-all/overview/understanding-dynamic-schemas"
+                ]
+              },
+              {
+                "group": "Endpoints",
+                "pages": [
+                  "v3/catch-all/endpoints/create-job",
+                  "v3/catch-all/endpoints/get-job-status",
+                  "v3/catch-all/endpoints/get-job-results"
+                ]
+              }
+            ]
           }
         ]
       },

--- a/v2/api-reference/news-api-v2.yml
+++ b/v2/api-reference/news-api-v2.yml
@@ -1329,4 +1329,4 @@ components:
         API Key to authenticate requests.
 
         To access the API, include your API key in the `x-api-key` header. 
-        To obtain your API key, complete the [form](https://www.newscatcherapi.com/pricing) or contact us directly.
+        To obtain your API key, complete the [form](https://www.newscatcherapi.com/book-a-demo) or contact us directly.

--- a/v3/api-reference/news-api-v3.yml
+++ b/v3/api-reference/news-api-v3.yml
@@ -4720,4 +4720,4 @@ components:
         API Key to authenticate requests.
 
         To access the API, include your API key in the `x-api-token` header. 
-        To obtain your API key, complete the [form](https://www.newscatcherapi.com/pricing) or contact us directly.
+        To obtain your API key, complete the [form](https://www.newscatcherapi.com/book-a-demo) or contact us directly.

--- a/v3/api-reference/overview/introduction.mdx
+++ b/v3/api-reference/overview/introduction.mdx
@@ -309,7 +309,7 @@ All API responses are in JSON format and typically include the following fields:
 
 To start using News API v3:
 
-1. [Contact our sales team](https://www.newscatcherapi.com/pricing) to discuss
+1. [Contact our sales team](https://www.newscatcherapi.com/book-a-demo) to discuss
    your enterprise needs and obtain an API key.
 2. Once you have your API key, check out our
    [Quickstart guide](/v3/documentation/get-started/quickstart) to make your

--- a/v3/catch-all/catch-all-api.yml
+++ b/v3/catch-all/catch-all-api.yml
@@ -1,0 +1,440 @@
+openapi: 3.1.0
+info:
+  title: NewsCatcher CatchAll API - Beta
+  version: 0.1.0
+  description: |
+    CatchAll transforms natural language questions into structured, validated records extracted from web sources.
+
+    ### Endpoints
+    - **POST /catchAll/submit**  
+      Create a new job. Requires `x-api-key` header. Request body: `{ "query": "..." }`
+
+    - **GET /catchAll/status/{job_id}**  
+      Returns the current status of a job
+
+    - **GET /catchAll/pull/{job_id}**  
+      Retrieves final results for a completed job
+
+    ### Authentication
+    All endpoints require `x-api-key` header. Invalid or missing key returns `403 Forbidden`.
+
+    ### Workflow
+    1. Submit a query with `/catchAll/submit`
+    2. Poll `/catchAll/status/{job_id}` until status is `job_completed` (typically 10-15 minutes)
+    3. Retrieve results with `/catchAll/pull/{job_id}`
+
+    ### Important Notes
+
+    **Dynamic Schemas**: Response schemas are generated dynamically by LLMs. Field names in the `enrichment` object vary between requests and are not fixed.
+
+    **Non-Deterministic**: Identical queries can produce different results due to LLM-based processing.
+
+  contact:
+    name: NewsCatcher AI
+    url: https://newscatcherapi.com
+    email: support@newscatcherapi.com
+
+externalDocs:
+  description: Find out more about NewsCatcher CatchAll API
+  url: https://newscatcherapi.com/docs/v3/catch-all
+
+servers:
+  - url: https://catchall.newscatcherapi.xyz
+    description: Production server
+
+tags:
+  - name: Jobs
+    description: Operations to create, monitor, and retrieve job results
+    externalDocs:
+      description: Learn about job lifecycle and status tracking
+      url: https://newscatcherapi.com/docs/v3/catch-all
+
+security:
+  - ApiKeyAuth: []
+
+paths:
+  /catchAll/submit:
+    post:
+      tags:
+        - Jobs
+      summary: Create job
+      description:
+        Submit a natural language query to create a new processing job.
+      operationId: createJob
+      externalDocs:
+        description: Detailed documentation for job creation
+        url: https://newscatcherapi.com/docs/v3/catch-all/endpoints/create-job
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubmitRequest"
+            example:
+              query: "Tech company earnings this quarter"
+              context: "Focus on revenue and profit margins"
+              summary_template: "Company [NAME] earned [REVENUE] in [QUARTER]"
+      responses:
+        "200":
+          $ref: "#/components/responses/SubmitResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+  /catchAll/status/{job_id}:
+    get:
+      tags:
+        - Jobs
+      summary: Get job status
+      description: Retrieve the current processing status of a job.
+      operationId: getJobStatus
+      externalDocs:
+        description: Understanding job statuses and polling
+        url: https://newscatcherapi.com/docs/v3/catch-all/endpoints/get-job-status
+      parameters:
+        - $ref: "#/components/parameters/JobId"
+      responses:
+        "200":
+          $ref: "#/components/responses/StatusResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
+  /catchAll/pull/{job_id}:
+    get:
+      tags:
+        - Jobs
+      summary: Get job results
+      description: Retrieve the final results for a completed job.
+      operationId: getJobResults
+      externalDocs:
+        description: Working with job results and dynamic schemas
+        url: https://newscatcherapi.com/docs/v3/catch-all/endpoints/get-job-results
+      parameters:
+        - $ref: "#/components/parameters/JobId"
+      responses:
+        "200":
+          $ref: "#/components/responses/PullResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
+components:
+  parameters:
+    JobId:
+      name: job_id
+      in: path
+      required: true
+      description: Unique job identifier returned from the submit endpoint
+      schema:
+        type: string
+        format: uuid
+      example: "af7a26d6-cf0b-458c-a6ed-4b6318c74da3"
+
+  responses:
+    SubmitResponse:
+      description: Job created successfully
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/SubmitResponseBody"
+          example:
+            job_id: "af7a26d6-cf0b-458c-a6ed-4b6318c74da3"
+
+    StatusResponse:
+      description: Status retrieved successfully
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/StatusResponseBody"
+          example:
+            job_id: "af7a26d6-cf0b-458c-a6ed-4b6318c74da3"
+            status: "data_fetched"
+
+    PullResponse:
+      description: Results retrieved successfully
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/PullResponseBody"
+
+    ForbiddenError:
+      description: Invalid or missing API key
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            detail: "Invalid API key"
+
+    NotFoundError:
+      description: Job not found or results not available
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            detail: "Job not found"
+
+    ValidationError:
+      description: Validation error in request body
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ValidationErrorResponse"
+
+  schemas:
+    Query:
+      type: string
+      description: |
+        Natural language question describing what to find. Can be any topic: company earnings, policy changes, product launches, M&A activity, etc.
+
+        The query is analyzed by an LLM to generate search queries, validators, and extractors. More specific queries produce more focused results.
+      example: "Tech company earnings this quarter"
+
+    Context:
+      type: string
+      description: |
+        Additional context to focus the search and extraction. Use this to narrow results to specific aspects of your query.
+
+        The context influences which articles are retrieved and which fields are extracted.
+      example: "Focus on revenue and profit margins"
+
+    SummaryTemplate:
+      type: string
+      description: |
+        Template string to guide record summary formatting. Use placeholder syntax like `[NAME]`, `[VALUE]`, `[DATE]` to indicate desired fields.
+
+        When provided, the API adds a `template_based_summary` field to each record's enrichment object following your template format. This does not guarantee specific field names in the enrichment object.
+      example: "Company [NAME] earned [REVENUE] in [QUARTER]"
+
+    SubmitRequest:
+      type: object
+      required:
+        - query
+      properties:
+        query:
+          $ref: "#/components/schemas/Query"
+        context:
+          $ref: "#/components/schemas/Context"
+        summary_template:
+          $ref: "#/components/schemas/SummaryTemplate"
+
+    SubmitResponseBody:
+      type: object
+      required:
+        - job_id
+      properties:
+        job_id:
+          type: string
+          format: uuid
+          description:
+            Unique identifier for the created job. Use this to check status and
+            retrieve results.
+          example: "af7a26d6-cf0b-458c-a6ed-4b6318c74da3"
+
+    JobStatus:
+      type: string
+      enum:
+        - pending
+        - analysis_started
+        - analysis_keywords_extracted
+        - analysis_enrichments_extracted
+        - analysis_queries_extracted
+        - retrieval_dispatched
+        - data_fetched
+        - clustering_dispatched
+        - data_grouped
+        - enrichment_dispatched
+        - data_enriched
+        - job_completed
+      description: |
+        Current job processing status. Jobs progress through these stages:
+
+        - `pending`: Job queued, waiting to start
+        - `analysis_started`: Beginning query analysis
+        - `analysis_keywords_extracted`: Keywords identified
+        - `analysis_enrichments_extracted`: Validators and extractors generated
+        - `analysis_queries_extracted`: Search queries created
+        - `retrieval_dispatched`: Queries sent to fetching service
+        - `data_fetched`: Articles retrieved
+        - `clustering_dispatched`: Clustering initiated
+        - `data_grouped`: Similar articles clustered
+        - `enrichment_dispatched`: Validation and extraction started
+        - `data_enriched`: Structured data extracted
+        - `job_completed`: Job finished, results ready
+
+        Poll every 30-60 seconds until status is `job_completed`.
+      example: "data_fetched"
+
+    StatusResponseBody:
+      type: object
+      required:
+        - job_id
+        - status
+      properties:
+        job_id:
+          type: string
+          format: uuid
+          description: Job identifier
+          example: "af7a26d6-cf0b-458c-a6ed-4b6318c74da3"
+        status:
+          $ref: "#/components/schemas/JobStatus"
+
+    PullResponseBody:
+      type: object
+      required:
+        - job_id
+        - status
+        - total_records
+        - records
+      properties:
+        job_id:
+          type: string
+          format: uuid
+          description: Job identifier
+        query:
+          type: string
+          description: Original natural language query
+          example: Tech company earnings this quarter
+        context:
+          type: string
+          description: Context provided with the query
+          example: Focus on revenue and profit margins
+        validation_criteria:
+          type: array
+          items:
+            type: string
+          description:
+            List of validation rules that were applied to filter results
+          example: ["is_current_quarter", "contains_financial_data"]
+        status:
+          type: string
+          description:
+            Job status (should be `job_completed` when pulling results)
+          example: "job_completed"
+        processing_time:
+          type: string
+          description: Total time taken to process the job
+          example: "15m"
+        sources_count:
+          type: integer
+          description: Number of articles initially retrieved from sources
+          example: 59150
+        total_records:
+          type: integer
+          description: Total number of validated records extracted
+          example: 2865
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/Record"
+          description:
+            Array of extracted records with structured data and citations
+
+    Record:
+      type: object
+      required:
+        - record_id
+        - enrichment
+        - citations
+      properties:
+        record_id:
+          type: string
+          description: Unique identifier for the record
+          example: "5262823697790152939"
+        enrichment:
+          type: object
+          description: |
+            Structured data extracted from articles. **Fields vary dynamically based on your query.**
+
+            Only `record_title` is guaranteed to be present. All other fields are generated by the LLM and adapt to the content found.
+
+            Field names are chosen semantically to match the content. For earnings data, you might see `revenue` or `quarterly_revenue`. For M&A data, you might see `acquirer` or `acquiring_company`.
+
+            See [Understanding dynamic schemas](https://newscatcherapi.com/docs/v3/catch-all/overview/understanding-dynamic-schemas) for integration guidance.
+          required:
+            - record_title
+          properties:
+            record_title:
+              type: string
+              description: Short title summarizing the record (always present)
+              example: "Oracle Q1 2026 Earnings Exceed Expectations"
+          additionalProperties: {}
+          example:
+            record_title: "Oracle Q1 2026 Earnings Exceed Expectations"
+            company_name: "Oracle"
+            quarter_identifier: "Q1 2026"
+            revenue: "$14.9 billion"
+            revenue_change: "up 12%"
+            profit_margin: "42% non-GAAP operating margin"
+        citations:
+          type: array
+          items:
+            $ref: "#/components/schemas/Citation"
+          description: Source articles that were used to extract this record
+
+    Citation:
+      type: object
+      required:
+        - title
+        - link
+        - published_date
+      properties:
+        title:
+          type: string
+          description: Article title
+          example: "Oracle Reports Strong Q1 2026 Results"
+        link:
+          type: string
+          format: uri
+          description: URL to the source article
+          example: "https://example.com/article"
+        published_date:
+          type: string
+          format: date-time
+          description: Article publication date in YYYY-MM-DD HH:MM:SS format
+          example: "2025-09-26 08:54:20"
+
+    Error:
+      type: object
+      properties:
+        detail:
+          type: string
+          description: Error message
+          example: "Invalid API key"
+
+    ValidationErrorDetail:
+      type: object
+      properties:
+        loc:
+          type: array
+          items:
+            oneOf:
+              - type: string
+              - type: integer
+          description: Location of the validation error
+        msg:
+          type: string
+          description: Error message
+        type:
+          type: string
+          description: Error type
+
+    ValidationErrorResponse:
+      type: object
+      properties:
+        detail:
+          type: array
+          items:
+            $ref: "#/components/schemas/ValidationErrorDetail"
+
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-api-key
+      description: API key for authentication

--- a/v3/catch-all/catch-all-api.yml
+++ b/v3/catch-all/catch-all-api.yml
@@ -128,7 +128,8 @@ components:
       name: job_id
       in: path
       required: true
-      description: Unique job identifier returned from the submit endpoint
+      description: |
+        Unique job identifier returned from the `/catchAll/submit` endpoint
       schema:
         type: string
         format: uuid
@@ -190,9 +191,10 @@ components:
     Query:
       type: string
       description: |
-        Natural language question describing what to find. Can be any topic: company earnings, policy changes, product launches, M&A activity, etc.
+        Natural language question that describes what you want to find. You can ask about any topic: company earnings, policy changes, product launches, M&A activity, and more.
 
-        The query is analyzed by an LLM to generate search queries, validators, and extractors. More specific queries produce more focused results.
+        The system analyzes your input to generate search queries, validators, and extractors. More specific queries produce more focused results.
+
       example: "Tech company earnings this quarter"
 
     Context:

--- a/v3/catch-all/endpoints/create-job.mdx
+++ b/v3/catch-all/endpoints/create-job.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api post /catchAll/submit
+---

--- a/v3/catch-all/endpoints/get-job-results.mdx
+++ b/v3/catch-all/endpoints/get-job-results.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api get /catchAll/pull/{job_id}
+---

--- a/v3/catch-all/endpoints/get-job-status.mdx
+++ b/v3/catch-all/endpoints/get-job-status.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api get /catchAll/status/{job_id}
+---

--- a/v3/catch-all/overview/introduction.mdx
+++ b/v3/catch-all/overview/introduction.mdx
@@ -18,7 +18,7 @@ relevant content from diverse sources (news sites, government databases, public
 records, corporate sites), clusters similar information, validates relevance,
 and extracts structured data tailored to your specific query.
 
-## How CatchAll works
+## How it works
 
 When you submit a query, CatchAll follows the multi-stage pipeline:
 

--- a/v3/catch-all/overview/introduction.mdx
+++ b/v3/catch-all/overview/introduction.mdx
@@ -296,8 +296,8 @@ These features are planned for implementation after the beta period:
 
 ## Getting started
 
-1. Visit our [pricing page](https://www.newscatcherapi.com/pricing) to get your
-   API key.
+1. [Book a demo](https://www.newscatcherapi.com/book-a-demo) and get your API
+   key.
 2. Follow the [Quickstart guide](/v3/catch-all/overview/quickstart) to make your
    first request.
 3. Review

--- a/v3/catch-all/overview/introduction.mdx
+++ b/v3/catch-all/overview/introduction.mdx
@@ -74,11 +74,11 @@ https://catchall.newscatcherapi.xyz
 
 ## Endpoints
 
-| Endpoint                    | Method | Description      | Use Case                                             |
-| --------------------------- | ------ | ---------------- | ---------------------------------------------------- |
-| `/catchAll/submit`          | POST   | Create a new job | Submit a natural language query to start processing  |
-| `/catchAll/status/{job_id}` | GET    | Check job status | Monitor processing progress through 12 status stages |
-| `/catchAll/pull/{job_id}`   | GET    | Get job results  | Retrieve structured records when job completes       |
+| Endpoint                    | Method | Description      | Use Case                                                                                                 |
+| --------------------------- | ------ | ---------------- | -------------------------------------------------------------------------------------------------------- |
+| `/catchAll/submit`          | POST   | Create a new job | Submit a natural language query to start processing                                                      |
+| `/catchAll/status/{job_id}` | GET    | Check job status | Monitor processing progress through 12 [status stages](/v3/catch-all/overview/introduction#job-statuses) |
+| `/catchAll/pull/{job_id}`   | GET    | Get job results  | Retrieve structured records when job completes                                                           |
 
 ## Request format
 

--- a/v3/catch-all/overview/introduction.mdx
+++ b/v3/catch-all/overview/introduction.mdx
@@ -6,10 +6,9 @@ description:
   web sources.
 ---
 
-CatchAll transforms natural language questions into structured, validated
-records extracted from web sources. The API lets you ask questions in plain
-English instead of using keywords and filters, and receive organized data with
-source citations.
+CatchAll transforms your natural language questions into structured, validated
+records from web sources. Ask questions in plain English and receive organized
+data with source citations—no need for complex keywords or filters.
 
 ## What is CatchAll API?
 
@@ -43,11 +42,11 @@ Processing typically takes 10-15 minutes per job.
 
 ### Dynamic schemas
 
-LLMs generate response schemas at runtime. The enrichment fields in records vary
-based on your inputs (`query`, `context`, `summary_template`). Only `record_id`,
-`record_title`, and `citations` are guaranteed in every record. If you specify
-`summary_template`, the `enrichment` object also includes the
-`template_base_summary` field.
+The system generates response formats dynamically based on your query. The
+enrichment fields in records vary based on your inputs (`query`, `context`,
+`summary_template`). Only `record_id`, `record_title`, and `citations` are
+guaranteed in every record. If you specify `summary_template`, the `enrichment`
+object also includes the `template_base_summary` field.
 
 To learn more, see the
 [Result response](/v3/catch-all/overview/introduction#results-response) example.
@@ -61,8 +60,8 @@ Identical queries can produce different results because:
 - Field names and structure vary between runs.
 - The number of records extracted can differ significantly.
 
-This behavior is expected and allows the system to adapt to any query type
-without predefined schemas.
+This flexibility allows the system to adapt to any query type without predefined
+schemas.
 
 ### Asynchronous processing
 

--- a/v3/catch-all/overview/introduction.mdx
+++ b/v3/catch-all/overview/introduction.mdx
@@ -7,8 +7,8 @@ description:
 ---
 
 CatchAll transforms natural language questions into structured, validated
-records extracted from web sources. Instead of searching with keywords and
-filters, you ask a question in plain English and receive organized data with
+records extracted from web sources. The API lets you ask questions in plain
+English instead of using keywords and filters, and receive organized data with
 source citations.
 
 ## What is CatchAll API?
@@ -19,22 +19,27 @@ relevant content from diverse sources (news sites, government databases, public
 records, corporate sites), clusters similar information, validates relevance,
 and extracts structured data tailored to your specific query.
 
-## How it works
+## How CatchAll works
 
-CatchAll processes your query through a multi-stage pipeline:
+When you submit a query, CatchAll follows the multi-stage pipeline:
 
-1. **Analyze**: Extracts keywords, generates validation rules and data.
-   extractors from your natural language query.
-2. **Fetch**: Retrieves relevant content from web sources using generated search
-   queries (typically 10 queries per job).
+1. **Analyse**: The LLM analyzes your inputs (`query`, `context`,
+   `summary_template`) to:
+   - Understand what information you need, produce keywords and search queries.
+   - Generate validators to filter relevant content.
+   - Create enrichments that define the output schema (which fields to extract
+     and their names).
+2. **Fetch**: Retrieves content from web sources using generated search queries.
 3. **Cluster**: Groups similar content into distinct events using embeddings.
-4. **Validate**: Applies LLM-based validation to filter relevant clusters.
-5. **Extract**: Extracts structured data with dynamically generated field names.
-6. **Return**: Provides structured records with source citations.
+4. **Validate**: Applies generated validators (from step 1) to filter relevant
+   clusters.
+5. **Extract**: Applies the pre-defined enrichments (from step 1) to extract
+   structured data.
+6. **Return**: Provides records according to generated output schema.
 
 Processing typically takes 10-15 minutes per job.
 
-## Key characteristics
+## Characteristics
 
 ### Dynamic schemas
 
@@ -283,7 +288,7 @@ unstructured web content:
 - **News aggregation**: Build topic-specific news applications with structured
   output.
 
-## Current limitations (Beta)
+## Beta limitations
 
 These features are planned for implementation after the beta period:
 
@@ -294,7 +299,7 @@ These features are planned for implementation after the beta period:
 - Query deduplication (submitting the same query creates separate jobs)
 - Pagination for large result sets
 
-## Getting started
+## Get started
 
 1. [Book a demo](https://www.newscatcherapi.com/book-a-demo) and get your API
    key.

--- a/v3/catch-all/overview/introduction.mdx
+++ b/v3/catch-all/overview/introduction.mdx
@@ -1,0 +1,309 @@
+---
+title: Introduction to CatchAll API
+sidebarTitle: Introduction
+description:
+  Transform natural language questions into structured, validated records from
+  web sources.
+---
+
+CatchAll transforms natural language questions into structured, validated
+records extracted from web sources. Instead of searching with keywords and
+filters, you ask a question in plain English and receive organized data with
+source citations.
+
+## What is CatchAll API?
+
+CatchAll provides an end-to-end pipeline for converting natural language queries
+into structured event data. The system analyzes your question, retrieves
+relevant content from diverse sources (news sites, government databases, public
+records, corporate sites), clusters similar information, validates relevance,
+and extracts structured data tailored to your specific query.
+
+## How it works
+
+CatchAll processes your query through a multi-stage pipeline:
+
+1. **Analyze**: Extracts keywords, generates validation rules and data.
+   extractors from your natural language query.
+2. **Fetch**: Retrieves relevant content from web sources using generated search
+   queries (typically 10 queries per job).
+3. **Cluster**: Groups similar content into distinct events using embeddings.
+4. **Validate**: Applies LLM-based validation to filter relevant clusters.
+5. **Extract**: Extracts structured data with dynamically generated field names.
+6. **Return**: Provides structured records with source citations.
+
+Processing typically takes 10-15 minutes per job.
+
+## Key characteristics
+
+### Dynamic schemas
+
+LLMs generate response schemas at runtime. The enrichment fields in records vary
+based on your inputs (`query`, `context`, `summary_template`). Only `record_id`,
+`record_title`, and `citations` are guaranteed in every record. If you specify
+`summary_template`, the `enrichment` object also includes the
+`template_base_summary` field.
+
+To learn more, see the
+[Result response](/v3/catch-all/overview/introduction#results-response) example.
+
+### Non-deterministic results
+
+Identical queries can produce different results because:
+
+- LLMs may generate different keywords, validators, and extractors.
+- Different content sources may be retrieved.
+- Field names and structure vary between runs.
+- The number of records extracted can differ significantly.
+
+This behavior is expected and allows the system to adapt to any query type
+without predefined schemas.
+
+### Asynchronous processing
+
+Each query creates a job that processes asynchronously. You receive a `job_id`
+to poll for status and retrieve results when complete.
+
+## Base URL
+
+For API requests use the following base URL:
+
+```bash
+https://catchall.newscatcherapi.xyz
+```
+
+## Endpoints
+
+| Endpoint                    | Method | Description      | Use Case                                             |
+| --------------------------- | ------ | ---------------- | ---------------------------------------------------- |
+| `/catchAll/submit`          | POST   | Create a new job | Submit a natural language query to start processing  |
+| `/catchAll/status/{job_id}` | GET    | Check job status | Monitor processing progress through 12 status stages |
+| `/catchAll/pull/{job_id}`   | GET    | Get job results  | Retrieve structured records when job completes       |
+
+## Request format
+
+Include your API key in the `x-api-key` header for each request. All requests
+must use HTTPS.
+
+### Basic request
+
+<CodeGroup>
+
+```json JSON
+{
+  "query": "Tech company earnings this quarter",
+  "context": "Focus on revenue and profit margins",
+  "summary_template": "Company [NAME] earned [REVENUE] in [QUARTER]"
+}
+```
+
+```python Python
+import requests
+import json
+
+API_KEY = "YOUR_API_KEY"
+URL = "https://catchall.newscatcherapi.xyz/catchAll/submit"
+HEADERS = {
+    "x-api-key": API_KEY,
+    "Content-Type": "application/json"
+}
+
+PAYLOAD = {
+    "query": "Tech company earnings this quarter",
+    "context": "Focus on revenue and profit margins",
+    "summary_template": "Company [NAME] earned [REVENUE] in [QUARTER]"
+}
+
+try:
+    response = requests.post(URL, headers=HEADERS, json=PAYLOAD)
+    response.raise_for_status()
+    print(json.dumps(response.json(), indent=2))
+except requests.exceptions.RequestException as e:
+    print(f"Failed to create job: {e}")
+```
+
+```typescript TypeScript
+const API_KEY = "YOUR_API_KEY";
+const URL = "https://catchall.newscatcherapi.xyz/catchAll/submit";
+
+const payload = {
+  query: "Tech company earnings this quarter",
+  context: "Focus on revenue and profit margins",
+  summary_template: "Company [NAME] earned [REVENUE] in [QUARTER]",
+};
+
+try {
+  const response = await fetch(URL, {
+    method: "POST",
+    headers: {
+      "x-api-key": API_KEY,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP error ${response.status}`);
+  }
+
+  const data = await response.json();
+  console.log(JSON.stringify(data, null, 2));
+} catch (error) {
+  console.error("Failed to create job:", error);
+}
+```
+
+```bash cURL
+curl -X POST \
+  'https://catchall.newscatcherapi.xyz/catchAll/submit' \
+  -H 'x-api-key: YOUR_API_KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "query": "Tech company earnings this quarter",
+    "context": "Focus on revenue and profit margins",
+    "summary_template": "Company [NAME] earned [REVENUE] in [QUARTER]"
+  }'
+```
+
+</CodeGroup>
+
+### Request parameters
+
+- **query** (string, required): Natural language question describing what to
+  find
+- **context** (string, optional): Additional context to focus search and
+  extraction
+- **summary_template** (string, optional): Template to guide record summary
+  formatting. When provided, adds a `template_based_summary` field to each
+  record
+
+## Response format
+
+### Job creation response
+
+```json
+{
+  "job_id": "af7a26d6-cf0b-458c-a6ed-4b6318c74da3"
+}
+```
+
+### Job status response
+
+```json
+{
+  "job_id": "af7a26d6-cf0b-458c-a6ed-4b6318c74da3",
+  "status": "data_fetched"
+}
+```
+
+The list of all job statuses available in the
+[Job statuses](/v3/catch-all/overview/introduction#job-statuses) section of this
+document.
+
+### Results response
+
+```json
+{
+  "job_id": "af7a26d6-cf0b-458c-a6ed-4b6318c74da3",
+  "query": "Tech company earnings this quarter",
+  "status": "job_completed",
+  "processing_time": "15m",
+  "sources_count": 59150,
+  "total_records": 2865,
+  "records": [
+    {
+      "record_id": "5262823697790152939",
+      "enrichment": {
+        "record_title": "Oracle Q1 2026 Earnings Exceed Expectations",
+        "company_name": "Oracle",
+        "quarter_identifier": "Q1 2026",
+        "revenue": "$14.9 billion",
+        "revenue_change": "up 12%",
+        "profit_margin": "42% non-GAAP operating margin",
+        "template_based_summary": "Company Oracle earned $14.9 billion in Q1 2026"
+      },
+      "citations": [
+        {
+          "title": "Oracle Reports Strong Q1 2026 Results",
+          "link": "https://example.com/article",
+          "published_date": "2025-09-26 08:54:20"
+        }
+      ]
+    }
+  ]
+}
+```
+
+<Warning>
+  The field names in the `enrichment` object are LLM-generated and may vary
+  event for the same inputs. The example above shows one possible structure for
+  earnings queries.
+</Warning>
+
+---
+
+## Job statuses
+
+To monitor the progress of your job, use the `/status/{job_id}` endpoint. We
+recommend polling this endpoint every 30-60 seconds.
+
+Jobs move through the following statuses:
+
+| Status                           | Description                                   | Typical Duration |
+| -------------------------------- | --------------------------------------------- | ---------------- |
+| `pending`                        | Job queued, waiting to start                  | Seconds          |
+| `analysis_started`               | Beginning query analysis                      | Seconds          |
+| `analysis_keywords_extracted`    | Keywords identified from query                | 30-60 seconds    |
+| `analysis_enrichments_extracted` | Validators and extractors generated           | 30-60 seconds    |
+| `analysis_queries_extracted`     | Search queries created (typically 10 queries) | 30-60 seconds    |
+| `retrieval_dispatched`           | Queries sent to fetching service              | Seconds          |
+| `data_fetched`                   | Articles retrieved from news database         | 3-5 minutes      |
+| `clustering_dispatched`          | Clustering process initiated                  | Seconds          |
+| `data_grouped`                   | Similar articles clustered                    | 2-4 minutes      |
+| `enrichment_dispatched`          | Validation and extraction started             | Seconds          |
+| `data_enriched`                  | Structured data extracted from valid clusters | 4-6 minutes      |
+| `job_completed`                  | Job finished, results ready                   | -                |
+
+---
+
+## Use cases
+
+CatchAll is designed for applications requiring structured data from
+unstructured web content:
+
+- **Market intelligence**: Track company earnings, M&A activity, product
+  launches.
+- **Regulatory monitoring**: Follow policy changes, government actions,
+  compliance updates.
+- **Business development**: Discover partnerships, funding rounds, market
+  entries.
+- **Competitive analysis**: Monitor competitor activities and announcements.
+- **Research automation**: Extract structured data for academic or business
+  research.
+- **News aggregation**: Build topic-specific news applications with structured
+  output.
+
+## Current limitations (Beta)
+
+These features are planned for implementation after the beta period:
+
+- Formal error handling and `failed` status
+- Error response objects with detailed failure information
+- Maximum job duration enforcement
+- Result expiration and cleanup
+- Query deduplication (submitting the same query creates separate jobs)
+- Pagination for large result sets
+
+## Getting started
+
+1. Visit our [pricing page](https://www.newscatcherapi.com/pricing) to get your
+   API key.
+2. Follow the [Quickstart guide](/v3/catch-all/overview/quickstart) to make your
+   first request.
+3. Review
+   [Understanding dynamic schemas](/v3/catch-all/overview/understanding-dynamic-schemas)
+   to learn how to handle variable response structures.
+4. Explore the [API Reference](/v3/catch-all/endpoints/create-job) for detailed
+   endpoint documentation.
+
+For technical support, contact us at support@newscatcherapi.com.

--- a/v3/catch-all/overview/quickstart.mdx
+++ b/v3/catch-all/overview/quickstart.mdx
@@ -11,8 +11,8 @@ questions into structured, validated records with source citations.
 
 Before you begin, make sure you meet these prerequisites:
 
-- An API key (obtain one through our
-  [pricing page](https://www.newscatcherapi.com/pricing))
+- An API key (obtain one through
+  [Book a demo](https://www.newscatcherapi.com/book-a-demo) page)
 - Basic understanding of REST APIs
 - Your preferred programming language and HTTP client
 - Basic knowledge of JSON data format

--- a/v3/catch-all/overview/quickstart.mdx
+++ b/v3/catch-all/overview/quickstart.mdx
@@ -22,7 +22,7 @@ Before you begin, make sure you meet these prerequisites:
 <Steps>
   <Step title="Set up your environment">
 
-    Make sure you have the necessary HTTP client library installed for your programming language:
+    Install the HTTP client library for your programming language:
 
     <CodeGroup>
     ```bash curl
@@ -128,7 +128,7 @@ Before you begin, make sure you meet these prerequisites:
       Replace `YOUR_API_KEY_HERE` with your actual API key.
     </Note>
 
-    You should receive a response with a job ID:
+    You receive a response with a job ID:
 
     ```json
     {

--- a/v3/catch-all/overview/quickstart.mdx
+++ b/v3/catch-all/overview/quickstart.mdx
@@ -1,0 +1,409 @@
+---
+title: CatchAll API quickstart guide
+sidebarTitle: Quickstart
+description: Get started with CatchAll API.
+---
+
+This guide helps you make your first API call to transform natural language
+questions into structured, validated records with source citations.
+
+## Before you start
+
+Before you begin, make sure you meet these prerequisites:
+
+- An API key (obtain one through our
+  [pricing page](https://www.newscatcherapi.com/pricing))
+- Basic understanding of REST APIs
+- Your preferred programming language and HTTP client
+- Basic knowledge of JSON data format
+
+## Steps
+
+<Steps>
+  <Step title="Set up your environment">
+
+    Make sure you have the necessary HTTP client library installed for your programming language:
+
+    <CodeGroup>
+    ```bash curl
+    # cURL is typically included in your system
+    # To check, open the terminal and type the following:
+    curl --version
+    ```
+
+    ```bash Python
+    pip install requests
+    ```
+
+    ```bash TypeScript
+    npm install axios
+    ```
+    </CodeGroup>
+
+  </Step>
+
+  <Step title="Create a job">
+
+    Submit a natural language query to create a new processing job:
+
+    <CodeGroup>
+    ```bash curl
+    curl -X POST https://catchall.newscatcherapi.xyz/catchAll/submit \
+      -H "x-api-key: YOUR_API_KEY_HERE" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "query": "Tech company earnings this quarter",
+        "context": "Focus on revenue and profit margins",
+        "summary_template": "Company [NAME] earned [REVENUE] in [QUARTER]"
+      }'
+    ```
+
+    ```json JSON
+    {
+      "query": "Tech company earnings this quarter",
+      "context": "Focus on revenue and profit margins",
+      "summary_template": "Company [NAME] earned [REVENUE] in [QUARTER]"
+    }
+    ```
+
+    ```python Python
+    import requests
+    import json
+
+    # Configuration
+    API_KEY = "YOUR_API_KEY_HERE"  # Replace with your actual API key
+    URL = "https://catchall.newscatcherapi.xyz/catchAll/submit"
+    HEADERS = {"x-api-key": API_KEY, "Content-Type": "application/json"}
+
+    # Define the job parameters
+    PAYLOAD = {
+        "query": "Tech company earnings this quarter",  # Natural language question
+        "context": "Focus on revenue and profit margins",  # Optional context
+        "summary_template": "Company [NAME] earned [REVENUE] in [QUARTER]"  # Optional template
+    }
+
+    try:
+        response = requests.post(URL, headers=HEADERS, json=PAYLOAD)
+        response.raise_for_status()
+        print(json.dumps(response.json(), indent=2))
+    except requests.exceptions.RequestException as e:
+        print(f"Failed to create job: {e}")
+    ```
+
+    ```typescript TypeScript
+    import axios, { AxiosResponse } from "axios";
+
+    const API_KEY: string = "YOUR_API_KEY_HERE";
+    const URL: string = "https://catchall.newscatcherapi.xyz/catchAll/submit";
+
+    interface JobPayload {
+      query: string;
+      context?: string;
+      summary_template?: string;
+    }
+
+    const payload: JobPayload = {
+      query: "Tech company earnings this quarter",
+      context: "Focus on revenue and profit margins",
+      summary_template: "Company [NAME] earned [REVENUE] in [QUARTER]"
+    };
+
+    axios
+      .post(URL, payload, {
+        headers: {
+          "x-api-key": API_KEY,
+          "Content-Type": "application/json"
+        }
+      })
+      .then((response: AxiosResponse) => {
+        console.log(JSON.stringify(response.data, null, 2));
+      })
+      .catch((error) => {
+        console.error(`Failed to create job: ${error.message}`);
+      });
+    ```
+    </CodeGroup>
+
+    <Note>
+      Replace `YOUR_API_KEY_HERE` with your actual API key.
+    </Note>
+
+    You should receive a response with a job ID:
+
+    ```json
+    {
+      "job_id": "af7a26d6-cf0b-458c-a6ed-4b6318c74da3"
+    }
+    ```
+
+    Use this `job_id` to check the status and retrieve results.
+
+  </Step>
+
+  <Step title="Check job status">
+
+    Wait 1-2 minutes, then check the processing status. Poll this endpoint every 30-60 seconds until the status is `job_completed`:
+
+    <CodeGroup>
+    ```bash curl
+    curl -X GET https://catchall.newscatcherapi.xyz/catchAll/status/af7a26d6-cf0b-458c-a6ed-4b6318c74da3 \
+      -H "x-api-key: YOUR_API_KEY_HERE"
+    ```
+
+    ```python Python
+    import requests
+    import time
+    import json
+
+    API_KEY = "YOUR_API_KEY_HERE"
+    JOB_ID = "af7a26d6-cf0b-458c-a6ed-4b6318c74da3"  # Job ID from previous step
+    URL = f"https://catchall.newscatcherapi.xyz/catchAll/status/{JOB_ID}"
+    HEADERS = {"x-api-key": API_KEY}
+
+    # Poll until job completes
+    while True:
+        try:
+            response = requests.get(URL, headers=HEADERS)
+            response.raise_for_status()
+            status_data = response.json()
+
+            print(f"Current status: {status_data['status']}")
+
+            if status_data['status'] == 'job_completed':
+                print("Job completed!")
+                break
+
+            time.sleep(60)  # Wait 60 seconds before next check
+
+        except requests.exceptions.RequestException as e:
+            print(f"Failed to check status: {e}")
+            break
+    ```
+
+    ```typescript TypeScript
+    import axios, { AxiosResponse } from "axios";
+
+    const API_KEY: string = "YOUR_API_KEY_HERE";
+    const JOB_ID: string = "af7a26d6-cf0b-458c-a6ed-4b6318c74da3";
+    const URL: string = `https://catchall.newscatcherapi.xyz/catchAll/status/${JOB_ID}`;
+
+    interface StatusResponse {
+      job_id: string;
+      status: string;
+    }
+
+    async function pollJobStatus() {
+      while (true) {
+        try {
+          const response: AxiosResponse<StatusResponse> = await axios.get(URL, {
+            headers: { "x-api-key": API_KEY }
+          });
+
+          console.log(`Current status: ${response.data.status}`);
+
+          if (response.data.status === "job_completed") {
+            console.log("Job completed!");
+            break;
+          }
+
+          await new Promise(resolve => setTimeout(resolve, 60000)); // Wait 60 seconds
+        } catch (error) {
+          console.error(`Failed to check status: ${error.message}`);
+          break;
+        }
+      }
+    }
+
+    pollJobStatus();
+    ```
+    </CodeGroup>
+
+    The response shows the current processing stage:
+
+    ```json
+    {
+      "job_id": "af7a26d6-cf0b-458c-a6ed-4b6318c74da3",
+      "status": "data_fetched"
+    }
+    ```
+
+    Jobs progress through statuses from `pending` to `job_completed`.
+    The list of all job statuses available in the [Introduction > Job statuses](/v3/catch-all/overview/introduction#job-statuses).
+
+    Processing typically takes 10-15 minutes.
+
+  </Step>
+
+  <Step title="Retrieve results">
+
+    Once the status is `job_completed`, retrieve the structured records:
+
+    <CodeGroup>
+    ```bash curl
+    curl -X GET https://catchall.newscatcherapi.xyz/catchAll/pull/af7a26d6-cf0b-458c-a6ed-4b6318c74da3 \
+      -H "x-api-key: YOUR_API_KEY_HERE"
+    ```
+
+    ```python Python
+    import requests
+    import json
+
+    API_KEY = "YOUR_API_KEY_HERE"
+    JOB_ID = "af7a26d6-cf0b-458c-a6ed-4b6318c74da3"
+    URL = f"https://catchall.newscatcherapi.xyz/catchAll/pull/{JOB_ID}"
+    HEADERS = {"x-api-key": API_KEY}
+
+    try:
+        response = requests.get(URL, headers=HEADERS)
+        response.raise_for_status()
+        results = response.json()
+
+        print(f"Query: {results['query']}")
+        print(f"Total records: {results['total_records']}")
+        print(f"Sources processed: {results['sources_count']}")
+        print(f"Processing time: {results['processing_time']}")
+
+        # Display first record
+        if results['records']:
+            record = results['records'][0]
+            print(f"\nFirst record: {record['enrichment']['record_title']}")
+            print("\nExtracted fields:")
+            for key, value in record['enrichment'].items():
+                if key != 'record_title':
+                    print(f"  {key}: {value}")
+
+    except requests.exceptions.RequestException as e:
+        print(f"Failed to retrieve results: {e}")
+    ```
+
+    ```typescript TypeScript
+    import axios, { AxiosResponse } from "axios";
+
+    const API_KEY: string = "YOUR_API_KEY_HERE";
+    const JOB_ID: string = "af7a26d6-cf0b-458c-a6ed-4b6318c74da3";
+    const URL: string = `https://catchall.newscatcherapi.xyz/catchAll/pull/${JOB_ID}`;
+
+    interface Enrichment {
+      record_title: string;
+      [key: string]: any;
+    }
+
+    interface Record {
+      record_id: string;
+      enrichment: Enrichment;
+      citations: Array<{
+        title: string;
+        link: string;
+        published_date: string;
+      }>;
+    }
+
+    interface ResultsResponse {
+      job_id: string;
+      query: string;
+      status: string;
+      processing_time: string;
+      sources_count: number;
+      total_records: number;
+      records: Record[];
+    }
+
+    axios
+      .get<ResultsResponse>(URL, {
+        headers: { "x-api-key": API_KEY }
+      })
+      .then((response: AxiosResponse<ResultsResponse>) => {
+        const results = response.data;
+
+        console.log(`Query: ${results.query}`);
+        console.log(`Total records: ${results.total_records}`);
+        console.log(`Sources processed: ${results.sources_count}`);
+        console.log(`Processing time: ${results.processing_time}`);
+
+        if (results.records.length > 0) {
+          const record = results.records[0];
+          console.log(`\nFirst record: ${record.enrichment.record_title}`);
+          console.log("\nExtracted fields:");
+          Object.entries(record.enrichment).forEach(([key, value]) => {
+            if (key !== "record_title") {
+              console.log(`  ${key}: ${value}`);
+            }
+          });
+        }
+      })
+      .catch((error) => {
+        console.error(`Failed to retrieve results: ${error.message}`);
+      });
+    ```
+    </CodeGroup>
+
+  </Step>
+
+  <Step title="Review the response">
+
+    The API returns structured records according to LLM-generated enrichment schema:
+
+    <Expandable title="Example response">
+
+    ```json JSON {17-26}
+    {
+      "job_id": "af7a26d6-cf0b-458c-a6ed-4b6318c74da3",
+      "query": "Tech company earnings this quarter",
+      "context": "Focus on revenue and profit margins",
+      "validation_criteria": [
+        "is_current_quarter",
+        "contains_financial_data",
+        "is_about_tech_company_earnings"
+      ],
+      "status": "job_completed",
+      "processing_time": "12m",
+      "sources_count": 59150,
+      "total_records": 2865,
+      "records": [
+        {
+          "record_id": "5262823697790152939",
+          "enrichment": {
+            "record_title": "Oracle Q1 2026 Earnings Exceed Expectations",
+            "company_name": "Oracle",
+            "quarter_identifier": "Q1 2026",
+            "revenue": "$14.9 billion",
+            "revenue_change": "up 12%",
+            "profit_margin": "42% non-GAAP operating margin",
+            "eps": "$1.47",
+            "template_based_summary": "Company Oracle earned $14.9 billion in Q1 2026"
+          },
+          "citations": [
+            {
+              "title": "Oracle Reports Strong Q1 2026 Results",
+              "link": "https://example.com/article",
+              "published_date": "2025-09-26 08:54:20"
+            }
+          ]
+        }
+      ]
+    }
+    ```
+
+    </Expandable>
+
+  </Step>
+</Steps>
+
+<Warning>
+  The field names in the `enrichment` object are LLM-generated and may vary
+  event for the same inputs. The example above shows one possible structure for
+  earnings queries.
+</Warning>
+
+## What's next
+
+Now that you've made your first calls to the CatchAll API:
+
+1. Read [Understanding dynamic schemas](understanding-dynamic-schemas.md) to
+   learn how to handle variable response structures in your code.
+2. Explore the [API Reference](https://catchall.newscatcherapi.xyz/docs) for
+   detailed endpoint documentation.
+3. Review the [Introduction](introduction.md) to understand how the processing
+   pipeline works.
+
+<Note>Need help? Contact our support team at support@newscatcherapi.com</Note>

--- a/v3/catch-all/overview/understanding-dynamic-schemas.mdx
+++ b/v3/catch-all/overview/understanding-dynamic-schemas.mdx
@@ -1,0 +1,552 @@
+---
+title: Understand dynamic schemas
+sidebarTitle: Dynamic schemas
+description:
+  Learn how CatchAll generates schemas dynamically with LLMs and how to build
+  integrations that handle non-deterministic responses.
+---
+
+CatchAll generates response schemas dynamically with LLMs. Each job creates a
+new schema, even with identical inputs. This guide explains this
+non-deterministic behavior and shows you how to build integrations that handle
+it.
+
+## Each job generates new schema
+
+When you submit a query, the LLM analyzes your inputs (`query`, `context`,
+`summary_template`) and generates extractors that define the output schema.
+Because LLMs are non-deterministic, the same inputs can produce different
+schemas on different runs.
+
+Expect the following variations:
+
+- Field names vary between jobs (even with identical inputs)
+- The number of fields can differ
+- Field structures may change (for example, combined fields versus separate
+  fields)
+- Results can vary significantly
+
+This is expected behavior, not a bug.
+
+## Example: Same inputs, different schemas
+
+This example shows how identical inputs produce different schemas.
+
+**Query:** "Tech company earnings this quarter"
+
+**Job 1 produced:**
+
+```json
+{
+  "record_title": "Oracle Q1 2026 Earnings",
+  "company_name": "Oracle",
+  "quarter_identifier": "Q1 2026",
+  "revenue": "$14.9 billion",
+  "revenue_change": "up 12%",
+  "profit_margin": "42%"
+}
+```
+
+**Job 2 produced:**
+
+```json
+{
+  "record_title": "Oracle Q1 2026 Results",
+  "company": "Oracle",
+  "quarter": "Q1",
+  "fiscal_year": "2026",
+  "total_revenue": "$14.9B",
+  "yoy_growth": "+12%",
+  "operating_margin": "42%"
+}
+```
+
+The field names differ:
+
+- `company_name` versus `company`
+- `quarter_identifier` versus `quarter` + `fiscal_year`
+- `revenue` versus `total_revenue`
+- `revenue_change` versus `yoy_growth`
+- `profit_margin` versus `operating_margin`
+
+Both schemas are valid. The LLM generated different extractors from the same
+inputs.
+
+## Fields that are always present
+
+The following fields appear in every record:
+
+- `record_id`
+- `enrichment.record_title`
+- `citations` array
+
+If you provide a `summary_template`, the enrichment object also includes:
+
+- `template_based_summary`
+
+All other fields in the `enrichment` object are generated dynamically for each
+job.
+
+## Handle variable schemas
+
+### 1. Don't hardcode field names
+
+<CodeGroup>
+
+```python Python
+# ❌ Breaks when field names change
+revenue = record["enrichment"]["revenue"]
+```
+
+```typescript TypeScript
+// ❌ Breaks when field names change
+const revenue = record.enrichment.revenue;
+```
+
+</CodeGroup>
+
+### 2. Check multiple possible names
+
+<CodeGroup>
+
+```python Python
+# ✅ Handles variations
+revenue = (
+    record["enrichment"].get("revenue") or
+    record["enrichment"].get("total_revenue") or
+    record["enrichment"].get("quarterly_revenue") or
+    "N/A"
+)
+```
+
+```typescript TypeScript
+// ✅ Handles variations
+const revenue =
+  record.enrichment.revenue ||
+  record.enrichment.total_revenue ||
+  record.enrichment.quarterly_revenue ||
+  "N/A";
+```
+
+</CodeGroup>
+
+### 3. Process all fields dynamically
+
+<CodeGroup>
+
+```python Python
+# ✅ Works with any schema
+enrichment = record["enrichment"]
+
+print(f"Title: {enrichment['record_title']}\n")
+
+for key, value in enrichment.items():
+    if key != "record_title":
+        display_name = key.replace("_", " ").title()
+        print(f"{display_name}: {value}")
+```
+
+```typescript TypeScript
+// ✅ Works with any schema
+const enrichment = record.enrichment;
+
+console.log(`Title: ${enrichment.record_title}\n`);
+
+for (const [key, value] of Object.entries(enrichment)) {
+  if (key !== "record_title") {
+    const displayName = key
+      .replace(/_/g, " ")
+      .split(" ")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
+    console.log(`${displayName}: ${value}`);
+  }
+}
+```
+
+</CodeGroup>
+
+### 4. Use pattern matching for key fields
+
+<CodeGroup>
+
+```python Python
+# ✅ Find fields by content, not exact name
+def find_field(enrichment, patterns):
+    """Find first field matching any pattern."""
+    for key, value in enrichment.items():
+        if any(pattern in key.lower() for pattern in patterns):
+            return value
+    return None
+
+# Usage
+revenue = find_field(record["enrichment"], ["revenue", "sales"])
+profit = find_field(record["enrichment"], ["profit", "margin", "income"])
+```
+
+```typescript TypeScript
+// ✅ Find fields by content, not exact name
+function findField(
+  enrichment: Record<string, any>,
+  patterns: string[]
+): any | null {
+  for (const [key, value] of Object.entries(enrichment)) {
+    if (patterns.some((pattern) => key.toLowerCase().includes(pattern))) {
+      return value;
+    }
+  }
+  return null;
+}
+
+// Usage
+const revenue = findField(record.enrichment, ["revenue", "sales"]);
+const profit = findField(record.enrichment, ["profit", "margin", "income"]);
+```
+
+</CodeGroup>
+
+## Integration strategies
+
+### Strategy 1: Store raw data
+
+Store the entire `enrichment` object as JSON. This preserves all fields
+regardless of schema:
+
+<CodeGroup>
+
+```python Python
+import json
+
+db.insert({
+    "record_id": record["record_id"],
+    "title": record["enrichment"]["record_title"],
+    "raw_data": json.dumps(record["enrichment"]),
+    "citations": json.dumps(record["citations"])
+})
+```
+
+```typescript TypeScript
+const dbRecord = {
+  record_id: record.record_id,
+  title: record.enrichment.record_title,
+  raw_data: JSON.stringify(record.enrichment),
+  citations: JSON.stringify(record.citations),
+};
+
+await db.insert(dbRecord);
+```
+
+</CodeGroup>
+
+### Strategy 2: Map to canonical fields
+
+Create a mapping layer between variable field names and your application's
+canonical names:
+
+<CodeGroup>
+
+```python Python
+FIELD_PATTERNS = {
+    "revenue": ["revenue", "sales", "total_revenue"],
+    "profit": ["profit", "margin", "income", "earnings"],
+    "quarter": ["quarter", "q", "period"],
+}
+
+def normalize_record(enrichment):
+    """Extract canonical fields from any schema."""
+    normalized = {"title": enrichment["record_title"]}
+
+    for canonical_name, patterns in FIELD_PATTERNS.items():
+        for key, value in enrichment.items():
+            if any(p in key.lower() for p in patterns):
+                normalized[canonical_name] = value
+                break
+
+    return normalized
+```
+
+```typescript TypeScript
+const FIELD_PATTERNS: Record<string, string[]> = {
+  revenue: ["revenue", "sales", "total_revenue"],
+  profit: ["profit", "margin", "income", "earnings"],
+  quarter: ["quarter", "q", "period"],
+};
+
+function normalizeRecord(enrichment: Record<string, any>): Record<string, any> {
+  const normalized: Record<string, any> = {
+    title: enrichment.record_title,
+  };
+
+  for (const [canonicalName, patterns] of Object.entries(FIELD_PATTERNS)) {
+    for (const [key, value] of Object.entries(enrichment)) {
+      if (patterns.some((p) => key.toLowerCase().includes(p))) {
+        normalized[canonicalName] = value;
+        break;
+      }
+    }
+  }
+
+  return normalized;
+}
+```
+
+</CodeGroup>
+
+### Strategy 3: Use flexible validation
+
+Validate structure, not specific fields:
+
+<CodeGroup>
+
+```python Python
+def is_valid_record(record):
+    """Validate record has required structure."""
+    # Check structure
+    if "enrichment" not in record or "citations" not in record:
+        return False
+
+    # Check guaranteed fields only
+    if "record_title" not in record["enrichment"]:
+        return False
+
+    # All other fields are optional
+    return True
+```
+
+```typescript TypeScript
+function isValidRecord(record: any): boolean {
+  // Check structure
+  if (!record.enrichment || !record.citations) {
+    return false;
+  }
+
+  // Check guaranteed fields only
+  if (!record.enrichment.record_title) {
+    return false;
+  }
+
+  // All other fields are optional
+  return true;
+}
+```
+
+</CodeGroup>
+
+## Use summary_template as guidance
+
+The `summary_template` parameter can influence field naming:
+
+```json
+{
+  "query": "Tech earnings",
+  "summary_template": "[COMPANY] earned [REVENUE] in [QUARTER]"
+}
+```
+
+This adds a `template_based_summary` field and may guide the LLM toward similar
+field names (for example, `company`, `revenue`, `quarter`), but doesn't
+guarantee them.
+
+Expect the following:
+
+- `template_based_summary` is always added
+- Field names may align with your placeholders
+- Specific field names are not guaranteed
+
+## Test for schema variations
+
+To understand how schemas vary, submit the same query multiple times:
+
+<CodeGroup>
+
+```python Python
+import time
+import requests
+
+# Submit same query 3 times
+job_ids = []
+for i in range(3):
+    response = requests.post(url, json={"query": "Tech earnings Q3"})
+    job_ids.append(response.json()["job_id"])
+    time.sleep(1)
+
+# Wait for completion and compare schemas
+for job_id in job_ids:
+    # Poll until complete
+    results = get_results(job_id)
+
+    # Print first record's fields
+    first_record = results["records"][0]["enrichment"]
+    print(f"\nJob {job_id} fields:")
+    print(list(first_record.keys()))
+```
+
+```typescript TypeScript
+import axios from "axios";
+
+// Submit same query 3 times
+const jobIds: string[] = [];
+for (let i = 0; i < 3; i++) {
+  const response = await axios.post(url, { query: "Tech earnings Q3" });
+  jobIds.push(response.data.job_id);
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+}
+
+// Wait for completion and compare schemas
+for (const jobId of jobIds) {
+  // Poll until complete
+  const results = await getResults(jobId);
+
+  // Print first record's fields
+  const firstRecord = results.records[0].enrichment;
+  console.log(`\nJob ${jobId} fields:`);
+  console.log(Object.keys(firstRecord));
+}
+```
+
+</CodeGroup>
+
+This reveals the range of schema variations you need to handle.
+
+## Avoid common mistakes
+
+### Don't expect consistency
+
+<CodeGroup>
+
+```python Python
+# ❌ Assumes all records have same fields
+df = pd.DataFrame([
+    {"company": r["enrichment"]["company_name"]}
+    for r in records
+])
+```
+
+```typescript TypeScript
+// ❌ Assumes all records have same fields
+const data = records.map((r) => ({
+  company: r.enrichment.company_name,
+}));
+```
+
+</CodeGroup>
+
+<CodeGroup>
+
+```python Python
+# ✅ Handles variable fields
+data = []
+for record in records:
+    row = {"title": record["enrichment"]["record_title"]}
+    # Add all other fields dynamically
+    row.update(record["enrichment"])
+    data.append(row)
+
+df = pd.DataFrame(data)
+```
+
+```typescript TypeScript
+// ✅ Handles variable fields
+const data = records.map((record) => ({
+  title: record.enrichment.record_title,
+  // Add all other fields dynamically
+  ...record.enrichment,
+}));
+```
+
+</CodeGroup>
+
+### Don't use rigid validation
+
+<CodeGroup>
+
+```python Python
+# ❌ Breaks on schema changes
+required_fields = ["company_name", "revenue", "quarter"]
+for field in required_fields:
+    assert field in enrichment
+```
+
+```typescript TypeScript
+// ❌ Breaks on schema changes
+const requiredFields = ["company_name", "revenue", "quarter"];
+requiredFields.forEach((field) => {
+  if (!(field in enrichment)) {
+    throw new Error(`Missing field: ${field}`);
+  }
+});
+```
+
+</CodeGroup>
+
+<CodeGroup>
+
+```python Python
+# ✅ Flexible validation
+assert "record_title" in enrichment  # Only check guaranteed fields
+```
+
+```typescript TypeScript
+// ✅ Flexible validation
+if (!("record_title" in enrichment)) {
+  throw new Error("Missing required field: record_title");
+}
+```
+
+</CodeGroup>
+
+### Don't assume field types
+
+<CodeGroup>
+
+```python Python
+# ❌ Field format can vary
+revenue_float = float(enrichment["revenue"].replace("$", ""))
+```
+
+```typescript TypeScript
+// ❌ Field format can vary
+const revenueFloat = parseFloat(enrichment.revenue.replace("$", ""));
+```
+
+</CodeGroup>
+
+<CodeGroup>
+
+```python Python
+# ✅ Handle different formats
+import re
+
+revenue_str = enrichment.get("revenue", "0")
+# Extract numbers from "$14.9B", "14.9 billion", "14900000000", etc.
+numbers = re.findall(r'[\d.]+', revenue_str)
+revenue_value = float(numbers[0]) if numbers else 0.0
+```
+
+```typescript TypeScript
+// ✅ Handle different formats
+const revenueStr = enrichment.revenue || "0";
+// Extract numbers from "$14.9B", "14.9 billion", "14900000000", etc.
+const numbers = revenueStr.match(/[\d.]+/);
+const revenueValue = numbers ? parseFloat(numbers[0]) : 0.0;
+```
+
+</CodeGroup>
+
+## Best practices
+
+To work effectively with CatchAll's LLM-generated schemas:
+
+1. **Store raw JSON**: Always preserve the original `enrichment` object.
+2. **Use pattern matching**: Match fields by content, not exact names.
+3. **Build mapping layers**: Translate variable schemas to your canonical model.
+4. **Test with multiple runs**: Submit identical queries to see variations.
+5. **Document variability**: Inform users that schemas change between jobs.
+6. **Handle missing fields gracefully**: Use `.get()` with defaults in Python or
+   optional chaining in TypeScript.
+
+<Tip>
+  The non-deterministic behavior lets CatchAll handle any query type without
+  predefined schemas. Build flexible integrations to leverage this capability
+  while maintaining robust code.
+</Tip>

--- a/v3/catch-all/overview/understanding-dynamic-schemas.mdx
+++ b/v3/catch-all/overview/understanding-dynamic-schemas.mdx
@@ -89,7 +89,7 @@ job.
 
 ## Handle variable schemas
 
-### 1. Don't hardcode field names
+### Don't hardcode field names
 
 <CodeGroup>
 
@@ -105,7 +105,7 @@ const revenue = record.enrichment.revenue;
 
 </CodeGroup>
 
-### 2. Check multiple possible names
+### Check multiple possible names
 
 <CodeGroup>
 
@@ -130,7 +130,7 @@ const revenue =
 
 </CodeGroup>
 
-### 3. Process all fields dynamically
+### Process all fields dynamically
 
 <CodeGroup>
 
@@ -166,7 +166,7 @@ for (const [key, value] of Object.entries(enrichment)) {
 
 </CodeGroup>
 
-### 4. Use pattern matching for key fields
+### Use pattern matching for key fields
 
 <CodeGroup>
 

--- a/v3/catch-all/overview/understanding-dynamic-schemas.mdx
+++ b/v3/catch-all/overview/understanding-dynamic-schemas.mdx
@@ -69,7 +69,7 @@ The field names differ:
 - `revenue_change` versus `yoy_growth`
 - `profit_margin` versus `operating_margin`
 
-Both schemas are valid. The LLM generated different extractors from the same
+Both schemas are valid. The LLM-generated different extractors from the same
 inputs.
 
 ## Fields that are always present

--- a/v3/documentation/get-started/news-api-v3-subscription-plans.mdx
+++ b/v3/documentation/get-started/news-api-v3-subscription-plans.mdx
@@ -101,8 +101,7 @@ Beyond our standard plans, we offer specialized enterprise solutions:
    - [Search in translations](/v3/documentation/how-to/seach-in-translations)
    - [Working with historical data](/v3/documentation/guides-and-concepts/working-with-historical-data)
 2. Explore the [API Reference](/v3/api-reference)
-3. Visit the [pricing page](https://www.newscatcherapi.com/pricing) to start
-   your subscription
+3. [Book a demo](https://www.newscatcherapi.com/book-a-demo).
 
 ## Support
 

--- a/v3/documentation/get-started/overview.mdx
+++ b/v3/documentation/get-started/overview.mdx
@@ -109,7 +109,7 @@ a two-step process:
 
 ### For decision makers
 
-1. [Contact our sales team](https://www.newscatcherapi.com/pricing) to discuss
+1. [Contact our sales team](https://www.newscatcherapi.com/book-a-demo) to discuss
    your enterprise needs and obtain an API key to access News API v3.
 2. Our team will work with you to set up a custom plan that fits your
    organization's scale and requirements.

--- a/v3/documentation/get-started/overview.mdx
+++ b/v3/documentation/get-started/overview.mdx
@@ -52,7 +52,7 @@ media analysis at a corporate level.
 
 At its core, the NewsCatcher News API v3 works by:
 
-1. **Collecting**: Continuously gathering news from over 70,000 web sources
+1. **Collecting**: Continuously gathering news from over 120,000 web sources
    globally, including major outlets and small local publishers.
 2. **Processing**: Applying advanced NLP techniques to enrich the content with
    metadata.
@@ -96,7 +96,7 @@ out in the enterprise space:
 
 | Feature                   | NewsCatcher News API v3     | Typical Enterprise News APIs |
 | ------------------------- | --------------------------- | ---------------------------- |
-| Global Coverage           | Over 70,000 News Sources    | Often Limited                |
+| Global Coverage           | Over 120,000 News Sources   | Often Limited                |
 | NLP Data Enrichment       | Comprehensive               | Basic or None                |
 | Search Flexibility        | High                        | Moderate                     |
 | Data Retrieval Efficiency | Up to 1000 articles/request | Usually less                 |
@@ -109,8 +109,8 @@ a two-step process:
 
 ### For decision makers
 
-1. [Contact our sales team](https://www.newscatcherapi.com/book-a-demo) to discuss
-   your enterprise needs and obtain an API key to access News API v3.
+1. [Contact our sales team](https://www.newscatcherapi.com/book-a-demo) to
+   discuss your enterprise needs and obtain an API key to access News API v3.
 2. Our team will work with you to set up a custom plan that fits your
    organization's scale and requirements.
 3. Once the contract is finalized, we'll initiate the onboarding process and

--- a/v3/documentation/migration/api-changes-v2-vs-v3.mdx
+++ b/v3/documentation/migration/api-changes-v2-vs-v3.mdx
@@ -123,11 +123,11 @@ The following features are available in all v3 plans.
 
 #### URLs
 
-| Parameter          | Type     | Description                                                     |
-| ------------------ | -------- | --------------------------------------------------------------- |
-| `parent_url`       | `string` | Filters articles by categorical URLs (e.g., "wsj.com/politics") |
-| `all_links`        | `string` | Filters articles by mentioned URLs within their content         |
-| `all_domain_links` | `string` | Filters articles by mentioned domain names within their content |
+| Parameter          | Type     | Description                                                         |
+| ------------------ | -------- | ------------------------------------------------------------------- |
+| `parent_url`       | `string` | Filters articles by categorical URLs (e.g., "www.wsj.com/politics") |
+| `all_links`        | `string` | Filters articles by mentioned URLs within their content             |
+| `all_domain_links` | `string` | Filters articles by mentioned domain names within their content     |
 
 #### Author
 

--- a/v3/events/events-api.yml
+++ b/v3/events/events-api.yml
@@ -30,7 +30,7 @@ info:
   contact:
     name: Maksym Sugonyaka
     email: maksym@newscatcherapi.com
-    url: https://www.newscatcherapi.com/pricing
+    url: https://www.newscatcherapi.com/book-a-demo
 
 externalDocs:
   description: Find out more about Events API
@@ -2089,4 +2089,4 @@ components:
         API Key to authenticate requests.
 
         To access the API, include your API key in the `x-api-token` header. 
-        To obtain your API key, complete the [form](https://www.newscatcherapi.com/pricing) or contact us directly.
+        To obtain your API key, complete the [form](https://www.newscatcherapi.com/book-a-demo) or contact us directly.

--- a/v3/events/overview/quickstart.mdx
+++ b/v3/events/overview/quickstart.mdx
@@ -12,8 +12,8 @@ from news articles.
 
 Before you begin, make sure you meet these prerequisites:
 
-- An API key (obtain one through our
-  [pricing page](https://www.newscatcherapi.com/pricing))
+- [Book a demo](https://www.newscatcherapi.com/book-a-demo) and obtain an API
+  key.
 - Basic understanding of REST APIs
 - Your preferred HTTP client (curl, Postman, etc.)
 - Basic knowledge of JSON data format

--- a/v3/local-news/local-news-api.yml
+++ b/v3/local-news/local-news-api.yml
@@ -27,7 +27,7 @@ info:
   contact:
     name: Maksym Sugonyaka
     email: maksym@newscatcherapi.com
-    url: https://www.newscatcherapi.com/pricing
+    url: https://www.newscatcherapi.com/book-a-demo
   version: 1.2.0
 
 externalDocs:
@@ -1893,4 +1893,4 @@ components:
         API Key to authenticate requests.
 
         To access the API, include your API key in the `x-api-token` header. 
-        To obtain your API key, complete the [form](https://www.newscatcherapi.com/pricing) or contact us directly.
+        To obtain your API key, complete the [form](https://www.newscatcherapi.com/book-a-demo) or contact us directly.

--- a/v3/local-news/overview/introduction.mdx
+++ b/v3/local-news/overview/introduction.mdx
@@ -20,22 +20,20 @@ outlets, university newspapers, and local government news portals.
 
 <Tabs>
   <Tab title="Location">
-    - Six distinct location detection methods 
-    - Content from thousands of local news sources across multiple countries 
-    - Advanced GeoNames filtering with administrative hierarchy, localization 
-      and confidence scores 
-    - Cross-language search using English keywords
+    - Six distinct location detection methods - Content from thousands of local
+    news sources across multiple countries - Advanced GeoNames filtering with
+    administrative hierarchy, localization and confidence scores -
+    Cross-language search using English keywords
   </Tab>
   <Tab title="Content">
-    - NLP analysis including summary, sentiment, theme, and entity recognition 
-    - Article clustering for related content grouping 
-    - English translations for non-English content with search and NLP support
+    - NLP analysis including summary, sentiment, theme, and entity recognition -
+    Article clustering for related content grouping - English translations for
+    non-English content with search and NLP support
   </Tab>
   <Tab title="Technical">
-    - Advanced query syntax with logical operators, wildcards, and proximity 
-      search capabilities 
-    - High-volume retrieval with up to 1000 articles per page 
-    - Comprehensive API with standard and advanced endpoints 
+    - Advanced query syntax with logical operators, wildcards, and proximity
+    search capabilities - High-volume retrieval with up to 1000 articles per
+    page - Comprehensive API with standard and advanced endpoints
   </Tab>
 </Tabs>
 
@@ -262,8 +260,8 @@ curl -X POST \
 
 ## Response differences
 
-Both endpoint types include basic article information with metadata, NLP and 
-translation fields (`title_translated_en`, `content_translated_en`). The main 
+Both endpoint types include basic article information with metadata, NLP and
+translation fields (`title_translated_en`, `content_translated_en`). The main
 difference between standard and advanced endpoints is the location data
 structure.
 
@@ -300,8 +298,8 @@ Return structured GeoNames data:
 ```
 
 <Note>
- For detailed information on all available response fields, see 
- [API Reference](/v3/local-news/endpoints/search/search-articles-post).
+  For detailed information on all available response fields, see [API
+  Reference](/v3/local-news/endpoints/search/search-articles-post).
 </Note>
 
 ## Use cases
@@ -322,8 +320,8 @@ intelligence:
 
 ## Getting started
 
-1. Visit our [pricing page](https://www.newscatcherapi.com/pricing) to get your
-   API key.
+1. [Book a demo](https://www.newscatcherapi.com/book-a-demo) to get your API
+   key.
 2. Follow the [Quickstart guide](/v3/local-news/overview/quickstart) to make
    your first request and comprehend the basic workflow.
 3. Review the

--- a/v3/local-news/overview/local-news-api-subscription-plans.mdx
+++ b/v3/local-news/overview/local-news-api-subscription-plans.mdx
@@ -98,6 +98,6 @@ If you need help selecting a plan, contact our team:
   [support@newscatcherapi.com](mailto:support@newscatcherapi.com)
 
 <Tip>
-  Visit the [pricing page](https://www.newscatcherapi.com/pricing) to start your
-  subscription.
+  [Book a demo](https://www.newscatcherapi.com/book-a-demo) and obtain your API
+  key.
 </Tip>

--- a/v3/local-news/overview/quickstart.mdx
+++ b/v3/local-news/overview/quickstart.mdx
@@ -11,8 +11,8 @@ location detection and filtering capabilities.
 
 Before you begin, make sure you meet these prerequisites:
 
-- An API key (obtain one through our
-  [pricing page](https://www.newscatcherapi.com/pricing))
+- An API key (obtain one through
+  [Book a demo](https://www.newscatcherapi.com/book-a-demo) page)
 - Basic understanding of REST APIs
 - Your preferred programming language and HTTP client
 - Basic knowledge of JSON data format


### PR DESCRIPTION
Introduce documentation for CatchAll API - a new product that transforms natural language queries into structured records from web sources.

Includes:
- Overview and quickstart guide
- OpenAPI specification
- Dynamic schema handling guide
- Core endpoint references
- Maintanance changes for v3, local news and other services

Status: Beta - minimal viable documentation set