### PR TITLE
Chore/catchall: refine CatchAll OAS, and expand client coverage for MCP

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -67,10 +67,10 @@
                 "pages": [
                   "web-search-api/api-reference/jobs/initialize-job",
                   "web-search-api/api-reference/jobs/create-job",
-                  "web-search-api/api-reference/jobs/continue-job",
-                  "web-search-api/api-reference/jobs/list-user-jobs",
                   "web-search-api/api-reference/jobs/get-job-status",
                   "web-search-api/api-reference/jobs/get-job-results",
+                  "web-search-api/api-reference/jobs/continue-job",
+                  "web-search-api/api-reference/jobs/list-user-jobs",
                   "web-search-api/api-reference/jobs/company-enrichment-dto"
                 ]
               },
@@ -78,12 +78,12 @@
                 "group": "Monitors",
                 "pages": [
                   "web-search-api/api-reference/monitors/create-monitor",
-                  "web-search-api/api-reference/monitors/update-monitor",
+                  "web-search-api/api-reference/monitors/get-monitor-results",
                   "web-search-api/api-reference/monitors/list-monitors",
                   "web-search-api/api-reference/monitors/list-monitor-jobs",
-                  "web-search-api/api-reference/monitors/get-monitor-results",
                   "web-search-api/api-reference/monitors/enable-monitor",
                   "web-search-api/api-reference/monitors/disable-monitor",
+                  "web-search-api/api-reference/monitors/update-monitor",
                   "web-search-api/api-reference/monitors/webhook-payload"
                 ]
               },

--- a/llms.txt
+++ b/llms.txt
@@ -29,21 +29,21 @@
 
 - [Initialize Job](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/initialize-job): Get suggested validators, enrichments, and date ranges for a query.
 - [Create Job](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/create-job): Submit a query to create a new processing job.
-- [Continue Job](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/continue-job): Continue an existing job to process more records beyond the initial limit.
-- [List User Jobs](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/list-user-jobs): Returns all jobs created by the authenticated user.
 - [Get Job Status](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/get-job-status): Retrieve the current processing status of a job.
 - [Get Job Results](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/get-job-results): Retrieve the final results for a completed job.
+- [Continue Job](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/continue-job): Continue an existing job to process more records beyond the initial limit.
+- [List User Jobs](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/list-user-jobs): Returns all jobs created by the authenticated user.
 - [Company enrichment](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/company-enrichment-dto): Data model for enrichment fields of type company.
 
 ### API Reference — Monitors
 
 - [Create Monitor](https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/create-monitor): Create a scheduled monitor based on a reference job.
-- [Update Monitor](https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/update-monitor): Update the webhook configuration for an existing monitor.
+- [Get Monitor Results](https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/get-monitor-results): Retrieve aggregated results from all jobs executed by a monitor.
 - [List Monitors](https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/list-monitors): Returns all monitors created by the authenticated user.
 - [List Monitor Jobs](https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/list-monitor-jobs): Return all jobs executed by a monitor.
-- [Get Monitor Results](https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/get-monitor-results): Retrieve aggregated results from all jobs executed by a monitor.
 - [Enable Monitor](https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/enable-monitor): Resume scheduled job execution for a monitor.
 - [Disable Monitor](https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/disable-monitor): Stop scheduled job execution for a monitor.
+- [Update Monitor](https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/update-monitor): Update the webhook configuration for an existing monitor.
 - [Webhook payload](https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/webhook-payload): Data model for a payload sent to the webhook URL when a monitor job completes.
 
 ### API Reference — Meta

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -40,16 +40,16 @@
         <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/create-job</loc>
     </url>
     <url>
-        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/continue-job</loc>
-    </url>
-    <url>
-        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/list-user-jobs</loc>
-    </url>
-    <url>
         <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/get-job-status</loc>
     </url>
     <url>
         <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/get-job-results</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/continue-job</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/list-user-jobs</loc>
     </url>
     <url>
         <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/company-enrichment-dto</loc>
@@ -58,7 +58,7 @@
         <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/create-monitor</loc>
     </url>
     <url>
-        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/update-monitor</loc>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/get-monitor-results</loc>
     </url>
     <url>
         <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/list-monitors</loc>
@@ -67,13 +67,13 @@
         <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/list-monitor-jobs</loc>
     </url>
     <url>
-        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/get-monitor-results</loc>
-    </url>
-    <url>
         <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/enable-monitor</loc>
     </url>
     <url>
         <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/disable-monitor</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/update-monitor</loc>
     </url>
     <url>
         <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/webhook-payload</loc>

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -59,6 +59,25 @@ security:
   - ApiKeyAuth: []
 
 paths:
+  /catchAll/jobs/user:
+    get:
+      tags:
+        - Jobs
+      summary: List user jobs
+      description: Returns all jobs created by the authenticated user.
+      operationId: getUserJobs
+      externalDocs:
+        description: Learn about job management
+        url: https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/list-user-jobs
+      parameters:
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          $ref: "#/components/responses/ListUserJobsResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+
   /catchAll/initialize:
     post:
       tags:
@@ -120,6 +139,48 @@ paths:
         "422":
           $ref: "#/components/responses/ValidationError"
 
+  /catchAll/status/{job_id}:
+    get:
+      tags:
+        - Jobs
+      summary: Get job status
+      description: Retrieve the current processing status of a job.
+      operationId: getJobStatus
+      externalDocs:
+        description: Understanding job statuses and polling
+        url: https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/get-job-status
+      parameters:
+        - $ref: "#/components/parameters/JobId"
+      responses:
+        "200":
+          $ref: "#/components/responses/StatusResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
+  /catchAll/pull/{job_id}:
+    get:
+      tags:
+        - Jobs
+      summary: Get job results
+      description: Retrieve the final results for a completed job.
+      operationId: getJobResults
+      externalDocs:
+        description: Working with job results and dynamic schemas
+        url: https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/get-job-results
+      parameters:
+        - $ref: "#/components/parameters/JobId"
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          $ref: "#/components/responses/PullJobResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
   /catchAll/continue:
     post:
       tags:
@@ -151,66 +212,23 @@ paths:
         "422":
           $ref: "#/components/responses/ValidationError"
 
-  /catchAll/status/{job_id}:
+  /catchAll/monitors:
     get:
       tags:
-        - Jobs
-      summary: Get job status
-      description: Retrieve the current processing status of a job.
-      operationId: getJobStatus
-      externalDocs:
-        description: Understanding job statuses and polling
-        url: https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/get-job-status
-      parameters:
-        - $ref: "#/components/parameters/JobId"
-      responses:
-        "200":
-          $ref: "#/components/responses/StatusResponse"
-        "403":
-          $ref: "#/components/responses/ForbiddenError"
-        "404":
-          $ref: "#/components/responses/NotFoundError"
-
-  /catchAll/jobs/user:
-    get:
-      tags:
-        - Jobs
-      summary: List user jobs
-      description: Returns all jobs created by the authenticated user.
-      operationId: getUserJobs
-      externalDocs:
-        description: Learn about job management
-        url: https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/list-user-jobs
+        - Monitors
+      summary: List monitors
+      description: Returns all monitors created by the authenticated user.
+      operationId: listMonitors
       parameters:
         - $ref: "#/components/parameters/Page"
         - $ref: "#/components/parameters/PageSize"
       responses:
         "200":
-          $ref: "#/components/responses/ListUserJobsResponse"
+          $ref: "#/components/responses/ListMonitorsResponse"
         "403":
           $ref: "#/components/responses/ForbiddenError"
-
-  /catchAll/pull/{job_id}:
-    get:
-      tags:
-        - Jobs
-      summary: Get job results
-      description: Retrieve the final results for a completed job.
-      operationId: getJobResults
-      externalDocs:
-        description: Working with job results and dynamic schemas
-        url: https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/get-job-results
-      parameters:
-        - $ref: "#/components/parameters/JobId"
-        - $ref: "#/components/parameters/Page"
-        - $ref: "#/components/parameters/PageSize"
-      responses:
-        "200":
-          $ref: "#/components/responses/PullJobResponse"
-        "403":
-          $ref: "#/components/responses/ForbiddenError"
-        "404":
-          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
 
   /catchAll/monitors/create:
     post:
@@ -241,16 +259,14 @@ paths:
         "422":
           $ref: "#/components/responses/ValidationError"
 
-  /catchAll/monitors/{monitor_id}:
-    patch:
+  /catchAll/monitors/pull/{monitor_id}:
+    get:
       tags:
         - Monitors
-      summary: Update monitor
-      description: Update the webhook configuration for an existing monitor.
-      operationId: updateMonitor
-      externalDocs:
-        description: Learn about monitor configuration
-        url: https://www.newscatcherapi.com/docs/web-search-api/how-to/configure-monitors
+      summary: Get monitor results
+      description:
+        Retrieve aggregated results from all jobs executed by a monitor.
+      operationId: pullMonitorResults
       parameters:
         - name: monitor_id
           in: path
@@ -259,23 +275,9 @@ paths:
             type: string
             format: uuid
           description: Monitor identifier.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/UpdateMonitorRequestDTO"
-            example:
-              webhook:
-                url: "https://new-endpoint.com/webhook"
-                method: "POST"
-                headers:
-                  Authorization: "Bearer new_token_xyz"
       responses:
         "200":
-          $ref: "#/components/responses/UpdateMonitorResponse"
-        "403":
-          $ref: "#/components/responses/ForbiddenError"
+          $ref: "#/components/responses/PullMonitorResponse"
         "404":
           $ref: "#/components/responses/NotFoundError"
         "422":
@@ -307,76 +309,6 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/ListMonitorJobsResponse"
-        "404":
-          $ref: "#/components/responses/NotFoundError"
-        "422":
-          $ref: "#/components/responses/ValidationError"
-
-  /catchAll/monitors/pull/{monitor_id}:
-    get:
-      tags:
-        - Monitors
-      summary: Get monitor results
-      description:
-        Retrieve aggregated results from all jobs executed by a monitor.
-      operationId: pullMonitorResults
-      parameters:
-        - name: monitor_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-          description: Monitor identifier.
-      responses:
-        "200":
-          $ref: "#/components/responses/PullMonitorResponse"
-        "404":
-          $ref: "#/components/responses/NotFoundError"
-        "422":
-          $ref: "#/components/responses/ValidationError"
-
-  /catchAll/monitors/{monitor_id}/disable:
-    post:
-      tags:
-        - Monitors
-      summary: Disable monitor
-      description: Stop scheduled job execution for a monitor.
-      operationId: disableMonitor
-      parameters:
-        - name: monitor_id
-          in: path
-          required: true
-          schema:
-            type: string
-            format: uuid
-          description: Monitor identifier.
-      responses:
-        "200":
-          description: Monitor disabled successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - success
-                  - message
-                  - monitor_id
-                properties:
-                  success:
-                    type: boolean
-                    description: Whether the operation succeeded.
-                    example: true
-                  message:
-                    type: string
-                    description: Human-readable success message.
-                    example: "Monitor disabled successfully."
-                  monitor_id:
-                    type: string
-                    format: uuid
-                    description: ID of the disabled monitor.
-        "403":
-          $ref: "#/components/responses/ForbiddenError"
         "404":
           $ref: "#/components/responses/NotFoundError"
         "422":
@@ -436,21 +368,89 @@ paths:
         "422":
           $ref: "#/components/responses/ValidationError"
 
-  /catchAll/monitors:
-    get:
+  /catchAll/monitors/{monitor_id}/disable:
+    post:
       tags:
         - Monitors
-      summary: List monitors
-      description: Returns all monitors created by the authenticated user.
-      operationId: listMonitors
+      summary: Disable monitor
+      description: Stop scheduled job execution for a monitor.
+      operationId: disableMonitor
       parameters:
-        - $ref: "#/components/parameters/Page"
-        - $ref: "#/components/parameters/PageSize"
+        - name: monitor_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Monitor identifier.
       responses:
         "200":
-          $ref: "#/components/responses/ListMonitorsResponse"
+          description: Monitor disabled successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - success
+                  - message
+                  - monitor_id
+                properties:
+                  success:
+                    type: boolean
+                    description: Whether the operation succeeded.
+                    example: true
+                  message:
+                    type: string
+                    description: Human-readable success message.
+                    example: "Monitor disabled successfully."
+                  monitor_id:
+                    type: string
+                    format: uuid
+                    description: ID of the disabled monitor.
         "403":
           $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+  /catchAll/monitors/{monitor_id}:
+    patch:
+      tags:
+        - Monitors
+      summary: Update monitor
+      description: Update the webhook configuration for an existing monitor.
+      operationId: updateMonitor
+      externalDocs:
+        description: Learn about monitor configuration
+        url: https://www.newscatcherapi.com/docs/web-search-api/how-to/configure-monitors
+      parameters:
+        - name: monitor_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Monitor identifier.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateMonitorRequestDTO"
+            example:
+              webhook:
+                url: "https://new-endpoint.com/webhook"
+                method: "POST"
+                headers:
+                  Authorization: "Bearer new_token_xyz"
+      responses:
+        "200":
+          $ref: "#/components/responses/UpdateMonitorResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
         "422":
           $ref: "#/components/responses/ValidationError"
 

--- a/web-search-api/integrations/mcp.mdx
+++ b/web-search-api/integrations/mcp.mdx
@@ -13,8 +13,8 @@ submit jobs, poll status, retrieve results, and manage monitors.
 
 - CatchAll API key from
   [platform.newscatcherapi.com](https://platform.newscatcherapi.com)
-- MCP-compatible client (Claude, Cursor, VS Code, Windsurf, or any client that
-  supports remote MCP)
+- MCP-compatible client (Claude, Cursor, VS Code, Windsurf, Zed, Warp, Gemini
+  CLI, Roo Code, or any client that supports remote MCP)
 
 ## Authentication
 
@@ -33,7 +33,7 @@ its connector UI does not support custom request headers.
   secret and do not share it or commit it to version control.
 </Warning>
 
-## Connect to client
+## Connect to Claude
 
 <Tabs>
   <Tab title="Claude.ai">
@@ -69,6 +69,7 @@ its connector UI does not support custom request headers.
     Claude Desktop supports remote MCP servers through the Connectors UI (**Settings > Customize > Connectors**) — the same flow as Claude.ai.
 
     Alternatively, you can configure it via a JSON config file. This approach does not support native remote MCP, so it requires `mcp-remote` as a proxy.
+
     <Steps>
       <Step title="Install Node.js">
         Run `node --version` to check if Node.js is installed. If the command fails, download and install it from [nodejs.org](https://nodejs.org) before continuing.
@@ -86,17 +87,16 @@ its connector UI does not support custom request headers.
         ```
       </Step>
       <Step title="Open configuration file">
-
         <Tabs>
           <Tab title="macOS">
-          ```txt
-          ~/Library/Application Support/Claude/claude_desktop_config.json
-          ```
+            ```txt
+            ~/Library/Application Support/Claude/claude_desktop_config.json
+            ```
           </Tab>
           <Tab title="Windows">
-          ```txt
-          %APPDATA%\Claude\claude_desktop_config.json
-          ```
+            ```txt
+            %APPDATA%\Claude\claude_desktop_config.json
+            ```
           </Tab>
         </Tabs>
 
@@ -149,19 +149,22 @@ its connector UI does not support custom request headers.
     </Tip>
 
   </Tab>
+</Tabs>
 
+## Connect to other clients
+
+<Tabs>
   <Tab title="Cursor">
-    Add to `~/.cursor/mcp.json`:
+    [![Install in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=catchall&config=eyJuYW1lIjoiY2F0Y2hhbGwiLCJ0eXBlIjoiaHR0cCIsInVybCI6Imh0dHBzOi8vY2F0Y2hhbGwtbWNwLm5ld3NjYXRjaGVyYXBpLmNvbS9tY3A/YXBpS2V5PVlPVVJfQ0FUQ0hBTExfQVBJX0tFWSJ9)
+
+    Or add to `~/.cursor/mcp.json` manually:
 
     ```json
     {
       "mcpServers": {
         "catchall": {
           "type": "http",
-          "url": "https://catchall-mcp.newscatcherapi.com/mcp",
-          "headers": {
-            "x-api-key": "YOUR_CATCHALL_API_KEY"
-          }
+          "url": "https://catchall-mcp.newscatcherapi.com/mcp?apiKey=YOUR_CATCHALL_API_KEY"
         }
       }
     }
@@ -172,17 +175,16 @@ its connector UI does not support custom request headers.
   </Tab>
 
   <Tab title="VS Code">
-    Add to `.vscode/mcp.json` in your project root:
+    [![Install in VS Code](https://img.shields.io/badge/Install_in-VS_Code-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=catchall&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fcatchall-mcp.newscatcherapi.com%2Fmcp%22%7D)
+
+    Or add to `.vscode/mcp.json` in your project root manually:
 
     ```json
     {
       "servers": {
         "catchall": {
           "type": "http",
-          "url": "https://catchall-mcp.newscatcherapi.com/mcp",
-          "headers": {
-            "x-api-key": "YOUR_CATCHALL_API_KEY"
-          }
+          "url": "https://catchall-mcp.newscatcherapi.com/mcp?apiKey=YOUR_CATCHALL_API_KEY"
         }
       }
     }
@@ -209,6 +211,83 @@ its connector UI does not support custom request headers.
     ```
 
     Restart Windsurf after saving.
+
+  </Tab>
+
+  <Tab title="Zed">
+    Add to your Zed settings (`~/.config/zed/settings.json`):
+
+    ```json
+    {
+      "context_servers": {
+        "catchall": {
+          "url": "https://catchall-mcp.newscatcherapi.com/mcp",
+          "headers": {
+            "x-api-key": "YOUR_CATCHALL_API_KEY"
+          }
+        }
+      }
+    }
+    ```
+
+    Restart Zed after saving.
+
+  </Tab>
+
+  <Tab title="Warp">
+    Go to **Settings > MCP Servers > Add MCP Server** and add:
+
+    ```json
+    {
+      "catchall": {
+        "url": "https://catchall-mcp.newscatcherapi.com/mcp",
+        "headers": {
+          "x-api-key": "YOUR_CATCHALL_API_KEY"
+        }
+      }
+    }
+    ```
+
+  </Tab>
+
+  <Tab title="Gemini CLI">
+    Add to `~/.gemini/settings.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "catchall": {
+          "httpUrl": "https://catchall-mcp.newscatcherapi.com/mcp",
+          "headers": {
+            "x-api-key": "YOUR_CATCHALL_API_KEY"
+          }
+        }
+      }
+    }
+    ```
+
+    Restart Gemini CLI after saving.
+
+  </Tab>
+
+  <Tab title="Roo Code">
+    Add to your Roo Code MCP config:
+
+    ```json
+    {
+      "mcpServers": {
+        "catchall": {
+          "type": "streamable-http",
+          "url": "https://catchall-mcp.newscatcherapi.com/mcp",
+          "headers": {
+            "x-api-key": "YOUR_CATCHALL_API_KEY"
+          }
+        }
+      }
+    }
+    ```
+
+    Restart Roo Code after saving.
 
   </Tab>
 
@@ -251,6 +330,11 @@ its connector UI does not support custom request headers.
   </Tab>
 </Tabs>
 
+<Note>
+  Replace `YOUR_CATCHALL_API_KEY` with your key. Do not share it or commit it
+  to version control.
+</Note>
+
 ## Available tools
 
 Each tool maps to a CatchAll API endpoint. For request and response schemas, see
@@ -279,7 +363,7 @@ the [API reference](/web-search-api/api-reference/jobs/create-job).
     | `enable_monitor` | Re-enable a previously disabled monitor |
     | `disable_monitor` | Pause a monitor without deleting it |
   </Tab>
-  
+
   <Tab title="Meta">
     | Tool | Description |
     |------|-------------|
@@ -299,15 +383,15 @@ the [API reference](/web-search-api/api-reference/jobs/create-job).
 <Accordion title="Connection refused or timeout">
   Verify your API key is valid by calling an authenticated endpoint:
 
-```bash
-curl -X POST "https://catchall.newscatcherapi.com/catchAll/initialize" \
-  -H "x-api-key: YOUR_CATCHALL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "test"}'
-```
+  ```bash
+  curl -X POST "https://catchall.newscatcherapi.com/catchAll/initialize" \
+    -H "x-api-key: YOUR_CATCHALL_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"query": "test"}'
+  ```
 
-If this returns a `403` error, your key is invalid. Check it at
-[platform.newscatcherapi.com](https://platform.newscatcherapi.com).
+  If this returns a `403` error, your key is invalid. Check it at
+  [platform.newscatcherapi.com](https://platform.newscatcherapi.com).
 
 </Accordion>
 


### PR DESCRIPTION
## What

Refines the order of endpoints in OAS for better machine-readability and changes the order in API reference pages. Expands MCP client coverage from 6 to 10 and splits the single "Connect to client" tab group into two sections by audience.

## Why
- The endpoint order (with in path params and root) could impact some tools that uses OAS to produce artifacts like SDKs, MPC servers, etc. 
- Requested broader MCP client coverage. The split reduces visual noise — Claude tabs have multi-step flows while all other clients are simple JSON snippets; grouping them together made the tab row unwieldy.

## Changes

- Reorder endpoints in machine-save and consistent order
- Split `## Connect to client` into `## Connect to Claude` and `## Connect to other clients`
- Add Zed, Warp, Gemini CLI, and Roo Code tabs (each with a distinct config format)
- Add one-click install buttons for Cursor and VS Code
- Update `Before you start` client list
- Move API key `<Note>` below both tab groups

## Testing

- [x] Manually verified Cursor deeplink redirects correctly
- [x] Manually verified VS Code deeplink installs without API key in URL
- [x] Confirmed all four new client config formats against Exa reference docs