### PR TITLE
docs(catchall): add complete documentation for company search

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -47,6 +47,7 @@
             "pages": [
               "web-search-api/guides-and-concepts/jobs",
               "web-search-api/guides-and-concepts/monitors",
+              "web-search-api/guides-and-concepts/company-search",
               "web-search-api/guides-and-concepts/index-and-search-depth",
               "web-search-api/guides-and-concepts/dynamic-schemas"
             ]

--- a/docs.json
+++ b/docs.json
@@ -88,6 +88,33 @@
                 ]
               },
               {
+                "group": "Entities",
+                "pages": [
+                  "web-search-api/api-reference/entities/list-entities",
+                  "web-search-api/api-reference/entities/create-entity",
+                  "web-search-api/api-reference/entities/create-entities-batch",
+                  "web-search-api/api-reference/entities/get-entity",
+                  "web-search-api/api-reference/entities/update-entity",
+                  "web-search-api/api-reference/entities/delete-entity"
+                ]
+              },
+              {
+                "group": "Datasets",
+                "pages": [
+                  "web-search-api/api-reference/datasets/list-datasets",
+                  "web-search-api/api-reference/datasets/create-dataset",
+                  "web-search-api/api-reference/datasets/create-dataset-from-csv",
+                  "web-search-api/api-reference/datasets/get-dataset",
+                  "web-search-api/api-reference/datasets/update-dataset",
+                  "web-search-api/api-reference/datasets/delete-dataset",
+                  "web-search-api/api-reference/datasets/list-entities-in-dataset",
+                  "web-search-api/api-reference/datasets/add-entities-to-dataset",
+                  "web-search-api/api-reference/datasets/remove-entities-from-dataset",
+                  "web-search-api/api-reference/datasets/get-dataset-status-history",
+                  "web-search-api/api-reference/datasets/upload-csv-to-dataset"
+                ]
+              },
+              {
                 "group": "Meta",
                 "pages": [
                   "web-search-api/api-reference/meta/health",

--- a/llms.txt
+++ b/llms.txt
@@ -16,6 +16,7 @@
 
 - [Jobs](https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/jobs): How CatchAll jobs work and how to move from query to results.
 - [Monitors](https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/monitors): Schedule recurring CatchAll jobs with webhook notifications.
+- [Company search](https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/company-search): Track specific companies across CatchAll jobs with per-company relevance scores.
 - [Understanding web index and search depth](https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/index-and-search-depth): How CatchAll's web index works and what start_date and end_date actually control.
 - [Working with dynamic schemas](https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/dynamic-schemas): Build integrations that handle variable field names and structures.
 
@@ -45,6 +46,87 @@
 - [Disable Monitor](https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/disable-monitor): Stop scheduled job execution for a monitor.
 - [Update Monitor](https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/update-monitor): Update the webhook configuration for an existing monitor.
 - [Webhook payload](https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/webhook-payload): Data model for a payload sent to the webhook URL when a monitor job completes.
+
+### API Reference — Entities
+
+- [List Entities](https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/list-entities): Returns a paginated list of entities belonging to the authenticated
+organization. Supports filtering by status and entity type, and
+sorting by name, status, or creation date.
+
+- [Create Entity](https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/create-entity): Creates a new company entity and begins background enrichment.
+
+The entity status starts as `pending` and transitions to `ready` once
+enrichment completes. Provide as much identifying information as
+possible — `domain` is the highest-signal field because it is
+unambiguous.
+
+- [Create Entities Batch](https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/create-entities-batch): Creates multiple entities in a single request. Each entity is
+processed independently — a failure in one does not affect others.
+
+Returns an array of `{id, status}` objects in the same order as
+the input array.
+
+- [Get Entity](https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/get-entity): Returns a single entity by ID with all attributes and current status.
+- [Update Entity](https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/update-entity): Updates one or more fields of an existing entity.
+
+- [Delete Entity](https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/delete-entity): Permanently deletes an entity. The entity is removed from all
+datasets and the search index. This operation cannot be undone.
+
+
+### API Reference — Datasets
+
+- [List Datasets](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/list-datasets): Returns a paginated list of datasets belonging to the authenticated
+organization. Supports filtering by status and sorting by name,
+status, or creation date.
+
+- [Create Dataset](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/create-dataset): Creates a new dataset from a list of existing entity IDs.
+
+If any of the provided entity IDs do not exist or do not belong to
+your organization, the request fails with `400`. All entity IDs must
+be valid before the dataset is created.
+
+To create a dataset and entities in one step, use the [`Create dataset from CSV`](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/create-dataset-from-csv)
+endpoint instead.
+
+- [Create Dataset From Csv](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/create-dataset-from-csv): Creates a new dataset by uploading a CSV file. Each row in the CSV
+becomes an entity. The `name` column is required; all other columns
+are optional.
+
+**CSV format:**
+```csv
+name,description,domain,alternative_names,key_persons
+NewsCatcher,"AI-powered news data provider",newscatcherapi.com,"NC;NewsCatcher API","Artem Bugara;Maksym Sugonyaka"
+OpenAI,"Artificial intelligence research company",openai.com,"Open AI","Sam Altman"
+```
+
+Use semicolons (`;`) to separate multiple values in `alternative_names` and `key_persons`. Rows with empty `name` are skipped and reported in `validation_report`. 
+
+**Note**: The response shape differs from the JSON dataset creation endpoint: it returns `dataset_id` (not `id`) and includes a `validation_report` with details on skipped rows.
+
+- [Get Dataset](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/get-dataset): Returns a single dataset by ID including entity count and current status.
+- [Update Dataset](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/update-dataset): Updates the name or description of a dataset.
+
+- [Delete Dataset](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/delete-dataset): Permanently deletes a dataset. The entities within the dataset are
+not deleted — only the dataset itself. This operation cannot be
+undone.
+
+- [List Entities In Dataset](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/list-entities-in-dataset): Returns a paginated list of entities in a dataset. Supports filtering by status and entity type.
+
+- [Add Entities To Dataset](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/add-entities-to-dataset): Adds one or more existing entities to a dataset. Returns the number of entities added.
+
+- [Remove Entities From Dataset](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/remove-entities-from-dataset): Removes one or more entities from a dataset. The entities themselves
+are not deleted — they are only removed from this dataset. Returns
+the number of entities removed.
+
+- [Get Dataset Status History](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/get-dataset-status-history): Returns the full status change history for a dataset, ordered
+chronologically from oldest to newest.
+
+- [Upload Csv To Dataset](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/upload-csv-to-dataset): Appends new companies to an existing dataset by uploading a CSV file.
+Uses the same CSV format as the dataset creation endpoint.
+
+The response omits `dataset_name` compared to the create-from-CSV
+endpoint since the dataset already exists.
+
 
 ### API Reference — Meta
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -19,6 +19,9 @@
         <loc>https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/monitors</loc>
     </url>
     <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/company-search</loc>
+    </url>
+    <url>
         <loc>https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/index-and-search-depth</loc>
     </url>
     <url>
@@ -77,6 +80,57 @@
     </url>
     <url>
         <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/webhook-payload</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/list-entities</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/create-entity</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/create-entities-batch</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/get-entity</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/update-entity</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/delete-entity</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/list-datasets</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/create-dataset</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/create-dataset-from-csv</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/get-dataset</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/update-dataset</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/delete-dataset</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/list-entities-in-dataset</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/add-entities-to-dataset</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/remove-entities-from-dataset</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/get-dataset-status-history</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/upload-csv-to-dataset</loc>
     </url>
     <url>
         <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/meta/health</loc>

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -87,6 +87,8 @@ security:
   - ApiKeyAuth: []
 
 paths:
+  # ── Jobs ──────────────────────────────────────────────────────────────
+
   /catchAll/jobs/user:
     get:
       tags:
@@ -239,6 +241,8 @@ paths:
           $ref: "#/components/responses/ForbiddenError"
         "422":
           $ref: "#/components/responses/ValidationError"
+
+  # ── Monitors ──────────────────────────────────────────────────────────────
 
   /catchAll/monitors:
     get:
@@ -482,6 +486,8 @@ paths:
         "422":
           $ref: "#/components/responses/ValidationError"
 
+  # ── Entities ──────────────────────────────────────────────────────────────
+
   /catchAll/entities/:
     get:
       tags:
@@ -703,6 +709,399 @@ paths:
           $ref: "#/components/responses/ForbiddenError"
         "404":
           $ref: "#/components/responses/NotFoundError"
+
+  # ── Datasets ──────────────────────────────────────────────────────────────
+
+  /catchAll/datasets/:
+    post:
+      tags:
+        - Datasets
+      summary: Create dataset
+      description: |
+        Creates a new dataset from a list of existing entity IDs.
+
+        If any of the provided entity IDs do not exist or do not belong to
+        your organization, the request fails with `400`. All entity IDs must
+        be valid before the dataset is created.
+
+        To create a dataset and entities in one step, use the CSV upload
+        endpoint instead.
+      operationId: createDataset
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateDatasetRequest"
+            example:
+              name: My Portfolio
+              description: Companies in our investment portfolio
+              entity_ids:
+                - 854198fa-f702-49db-a381-0427fa87f173
+                - a1b2c3d4-e5f6-7890-abcd-ef1234567890
+      responses:
+        "200":
+          $ref: "#/components/responses/DatasetResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+    get:
+      tags:
+        - Datasets
+      summary: List datasets
+      description: |
+        Returns a paginated list of datasets belonging to the authenticated
+        organization. Supports filtering by status and sorting by name,
+        status, or creation date.
+      operationId: listDatasets
+      parameters:
+        - $ref: "#/components/parameters/Page"
+        - name: page_size
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+            maximum: 500
+          description: Number of datasets per page.
+        - name: search
+          in: query
+          required: false
+          schema:
+            type: string
+          description:
+            Filter datasets by name (case-insensitive substring match).
+          example: Portfolio
+        - name: latest_status
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/DatasetStatus"
+          description: |
+            Filter by dataset status. Note: the query parameter is named
+            `latest_status`, not `status`.
+        - name: sort_by
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/DatasetSortBy"
+          description: Field to sort by. Defaults to `created_at`.
+        - name: sort_order
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/SortOrder"
+          description: Sort direction. Defaults to `desc`.
+      responses:
+        "200":
+          $ref: "#/components/responses/DatasetListResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+
+  /catchAll/datasets/upload:
+    post:
+      tags:
+        - Datasets
+      summary: Create dataset from CSV
+      description: |
+        Creates a new dataset by uploading a CSV file. Each row in the CSV
+        becomes an entity. The `name` column is required; all other columns
+        are optional.
+
+        **CSV format:**
+        ```
+        name,description,domain,alternative_names,key_persons
+        NewsCatcher,"AI-powered news data provider",newscatcherapi.com,"NC;NewsCatcher API","Artem Bugara;Maksym Sugonyaka"
+        OpenAI,"Artificial intelligence research company",openai.com,"Open AI","Sam Altman"
+        ```
+
+        Use semicolons (`;`) to separate multiple values in
+        `alternative_names` and `key_persons`. Rows with an empty `name`
+        field are skipped and reported in the `validation_report`.
+
+        The response shape differs from the JSON dataset creation endpoint:
+        it returns `dataset_id` (not `id`) and includes a `validation_report`
+        with details on any skipped rows.
+      operationId: createDatasetFromCSV
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+                - name
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: The CSV file to upload.
+                name:
+                  type: string
+                  description: Name for the new dataset.
+                  example: My Portfolio
+                description:
+                  type: string
+                  description: Optional description for the dataset.
+                  example: Companies from Q1 2026 watchlist
+      responses:
+        "200":
+          $ref: "#/components/responses/CreateDatasetCSVResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+  /catchAll/datasets/{dataset_id}:
+    get:
+      tags:
+        - Datasets
+      summary: Get dataset
+      description:
+        Returns a single dataset by ID including entity count and current
+        status.
+      operationId: getDataset
+      parameters:
+        - $ref: "#/components/parameters/DatasetId"
+      responses:
+        "200":
+          $ref: "#/components/responses/DatasetResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
+    patch:
+      tags:
+        - Datasets
+      summary: Update dataset
+      description: |
+        Updates the name or description of a dataset. Only `name` and
+        `description` can be updated. To change the entities in a dataset,
+        use the add or remove entity endpoints.
+      operationId: updateDataset
+      parameters:
+        - $ref: "#/components/parameters/DatasetId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateDatasetRequest"
+            example:
+              name: My Portfolio (updated)
+              description: Updated Q1 2026 watchlist
+      responses:
+        "200":
+          $ref: "#/components/responses/DatasetResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+    delete:
+      tags:
+        - Datasets
+      summary: Delete dataset
+      description: |
+        Permanently deletes a dataset. The entities within the dataset are
+        not deleted — only the dataset itself. This operation cannot be
+        undone.
+      operationId: deleteDataset
+      parameters:
+        - $ref: "#/components/parameters/DatasetId"
+      responses:
+        "204":
+          description: Dataset deleted successfully. No response body.
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
+  /catchAll/datasets/{dataset_id}/entities:
+    post:
+      tags:
+        - Datasets
+      summary: Add entities to dataset
+      description: |
+        Adds one or more existing entities to a dataset. Returns the number
+        of entities added.
+      operationId: addEntitiesToDataset
+      parameters:
+        - $ref: "#/components/parameters/DatasetId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DatasetEntityIdsRequest"
+            example:
+              entity_ids:
+                - 854198fa-f702-49db-a381-0427fa87f173
+      responses:
+        "200":
+          $ref: "#/components/responses/ManageEntitiesResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+    delete:
+      tags:
+        - Datasets
+      summary: Remove entities from dataset
+      description: |
+        Removes one or more entities from a dataset. The entities themselves
+        are not deleted — they are only removed from this dataset. Returns
+        the number of entities removed.
+      operationId: removeEntitiesFromDataset
+      parameters:
+        - $ref: "#/components/parameters/DatasetId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DatasetEntityIdsRequest"
+            example:
+              entity_ids:
+                - 854198fa-f702-49db-a381-0427fa87f173
+      responses:
+        "200":
+          $ref: "#/components/responses/ManageEntitiesResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+    get:
+      tags:
+        - Datasets
+      summary: List entities in dataset
+      description: |
+        Returns a paginated list of entities in a dataset. Supports filtering
+        by status and entity type.
+
+        Note: entities returned here use a summary shape with a flat
+        `attributes` key rather than the nested
+        `additional_attributes.company_attributes` structure used in the
+        standalone entity endpoints.
+      operationId: listEntitiesInDataset
+      parameters:
+        - $ref: "#/components/parameters/DatasetId"
+        - $ref: "#/components/parameters/Page"
+        - name: page_size
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+            maximum: 500
+          description: Number of entities per page.
+        - name: search
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter entities by name.
+        - name: status
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/EntityStatus"
+        - name: entity_type
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/EntityType"
+        - name: sort_by
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/EntitySortBy"
+        - name: sort_order
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/SortOrder"
+      responses:
+        "200":
+          $ref: "#/components/responses/DatasetEntityListResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
+  /catchAll/datasets/{dataset_id}/status:
+    get:
+      tags:
+        - Datasets
+      summary: Get dataset status history
+      description: |
+        Returns the full status change history for a dataset, ordered
+        chronologically from oldest to newest.
+      operationId: getDatasetStatusHistory
+      parameters:
+        - $ref: "#/components/parameters/DatasetId"
+      responses:
+        "200":
+          $ref: "#/components/responses/DatasetStatusHistoryResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
+  /catchAll/datasets/{dataset_id}/upload:
+    post:
+      tags:
+        - Datasets
+      summary: Add companies to dataset via CSV
+      description: |
+        Appends new companies to an existing dataset by uploading a CSV file.
+        Uses the same CSV format as the dataset creation endpoint.
+
+        The response omits `dataset_name` compared to the create-from-CSV
+        endpoint since the dataset already exists.
+      operationId: uploadCSVToDataset
+      parameters:
+        - $ref: "#/components/parameters/DatasetId"
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: The CSV file to upload.
+      responses:
+        "200":
+          $ref: "#/components/responses/UploadCSVToDatasetResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+  # ── Meta ──────────────────────────────────────────────────────────────
 
   /health:
     get:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -482,6 +482,228 @@ paths:
         "422":
           $ref: "#/components/responses/ValidationError"
 
+  /catchAll/entities/:
+    get:
+      tags:
+        - Entities
+      summary: List entities
+      description: |
+        Returns a paginated list of entities belonging to the authenticated
+        organization. Supports filtering by status and entity type, and
+        sorting by name, status, or creation date.
+      operationId: listEntities
+      parameters:
+        - $ref: "#/components/parameters/Page"
+        - name: page_size
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+            maximum: 500
+          description: Number of entities per page.
+        - name: search
+          in: query
+          required: false
+          schema:
+            type: string
+          description:
+            Filter entities by name (case-insensitive substring match).
+          example: NewsCatcher
+        - name: status
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/EntityStatus"
+          description: Filter by entity status.
+        - name: entity_type
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/EntityType"
+          description: Filter by entity type.
+        - name: sort_by
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/EntitySortBy"
+          description: Field to sort by. Defaults to `created_at`.
+        - name: sort_order
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/SortOrder"
+          description: Sort direction. Defaults to `desc`.
+      responses:
+        "200":
+          $ref: "#/components/responses/EntityListResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+
+    post:
+      tags:
+        - Entities
+      summary: Create entity
+      description: |
+        Creates a new company entity and begins background enrichment.
+
+        The entity status starts as `pending` and transitions to `ready` once
+        enrichment completes. Provide as much identifying information as
+        possible — `domain` is the highest-signal field because it is
+        unambiguous.
+
+        Only `name` is required. All other fields are optional but improve
+        matching quality.
+      operationId: createEntity
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateEntityRequest"
+            example:
+              name: NewsCatcher
+              entity_type: company
+              description: AI-powered news data provider
+              additional_attributes:
+                company_attributes:
+                  domain: newscatcherapi.com
+                  alternative_names:
+                    - NC
+                    - NewsCatcher API
+                  key_persons:
+                    - Artem Bugara
+                    - Maksym Sugonyaka
+      responses:
+        "200":
+          $ref: "#/components/responses/CreateEntityResponse"
+        "400":
+          $ref: "#/components/responses/EntityBadRequestError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+
+  /catchAll/entities/batch:
+    post:
+      tags:
+        - Entities
+      summary: Create entities in batch
+      description: |
+        Creates multiple entities in a single request. Each entity is
+        processed independently — a failure in one does not affect others.
+
+        Returns an array of `{id, status}` objects in the same order as
+        the input array.
+      operationId: createEntitiesBatch
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateEntitiesBatchRequest"
+            example:
+              entities:
+                - name: OpenAI
+                  entity_type: company
+                  description: Artificial intelligence research company
+                  additional_attributes:
+                    company_attributes:
+                      domain: openai.com
+                      alternative_names:
+                        - Open AI
+                      key_persons:
+                        - Sam Altman
+                - name: Stripe
+                  entity_type: company
+                  description: Online payment processing platform
+                  additional_attributes:
+                    company_attributes:
+                      domain: stripe.com
+                      key_persons:
+                        - Patrick Collison
+                        - John Collison
+      responses:
+        "200":
+          $ref: "#/components/responses/CreateEntitiesBatchResponse"
+        "400":
+          $ref: "#/components/responses/EntityBadRequestError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+
+  /catchAll/entities/{entity_id}:
+    get:
+      tags:
+        - Entities
+      summary: Get entity
+      description:
+        Returns a single entity by ID with all attributes and current status.
+      operationId: getEntity
+      parameters:
+        - $ref: "#/components/parameters/EntityId"
+      responses:
+        "200":
+          $ref: "#/components/responses/EntityResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
+    patch:
+      tags:
+        - Entities
+      summary: Update entity
+      description: |
+        Updates one or more fields of an existing entity. All fields are
+        optional — fields not included in the request body are left unchanged.
+
+        **Note:** when updating `additional_attributes.company_attributes`,
+        the provided object replaces the existing `company_attributes` in
+        full. Include all attribute fields you want to retain.
+      operationId: updateEntity
+      parameters:
+        - $ref: "#/components/parameters/EntityId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateEntityRequest"
+            example:
+              description: Updated description
+              additional_attributes:
+                company_attributes:
+                  alternative_names:
+                    - NC
+                    - NewsCatcher API
+                    - NCA
+      responses:
+        "200":
+          $ref: "#/components/responses/EntityResponse"
+        "400":
+          $ref: "#/components/responses/EntityBadRequestError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
+    delete:
+      tags:
+        - Entities
+      summary: Delete entity
+      description: |
+        Permanently deletes an entity. The entity is removed from all
+        datasets and the search index. This operation cannot be undone.
+      operationId: deleteEntity
+      parameters:
+        - $ref: "#/components/parameters/EntityId"
+      responses:
+        "204":
+          description: Entity deleted successfully. No response body.
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
   /health:
     get:
       tags:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NewsCatcher CatchAll API
-  version: 1.3.1
+  version: 1.4.0
   description: |
     CatchAll is a web search API that generates unique datasets that don't exist anywhere else on the web. Built on NewsCatcher's proprietary real-world event index, it delivers state-of-the-art recall—finding all relevant events, not just top results.
 
@@ -9,7 +9,7 @@ info:
 
     All endpoints except /health and /version require `x-api-key` header. If the key is invalid or missing, the API returns the `403 Forbidden` error.
 
-    ### Basic Workflow
+    ### Job workflow
 
     1. (Optional) Get suggestions via /catchAll/initialize
     2. Submit a query via /catchAll/submit with optional date ranges and custom validators/enrichments
@@ -22,9 +22,17 @@ info:
     2. Create monitor via /catchAll/monitors/create with schedule
     3. Retrieve aggregated results via /catchAll/monitors/pull/{monitor_id}
 
+    ### Company search workflow
+
+    1. Create a dataset via `POST /catchAll/datasets/` or `POST /catchAll/datasets/upload`
+    2. Wait for the dataset `latest_status` to reach `ready`
+    3. Submit a job with `connected_dataset_ids` pointing to your dataset
+    4. Retrieve results — each record includes a `connected_entities` array
+       with relevance scores per matched company
+
     ### Important notes
 
-    **Dynamic schemas**: Response schemas are generated dynamically by LLMs. Field names in the `enrichment` object may vary and are not deterministic across jobs.
+    **Dynamic schemas**: Response schemas are generated dynamically by LLMs. Field names in the `enrichment` object may vary and are not deterministic across jobs unless explicitly specified.
 
   contact:
     name: NewsCatcher

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -124,7 +124,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/InitializeRequestDTO"
+              $ref: "#/components/schemas/InitializeRequestDto"
             example:
               query: "Series B funding rounds for SaaS startups"
               context: "Focus on funding amount and company name"
@@ -151,7 +151,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SubmitRequestDTO"
+              $ref: "#/components/schemas/SubmitRequestDto"
             example:
               query: "Series B funding rounds for SaaS startups"
               context: "Focus on funding amount and company name"
@@ -228,7 +228,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ContinueRequestDTO"
+              $ref: "#/components/schemas/ContinueRequestDto"
             example:
               job_id: "5f0c9087-85cb-4917-b3c7-e5a5eff73a0c"
               new_limit: 100
@@ -274,7 +274,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateMonitorRequestDTO"
+              $ref: "#/components/schemas/CreateMonitorRequestDto"
             example:
               reference_job_id: "5f0c9087-85cb-4917-b3c7-e5a5eff73a0c"
               schedule: "every day at 12 PM UTC"
@@ -366,7 +366,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/EnableMonitorRequestDTO"
+              $ref: "#/components/schemas/EnableMonitorRequestDto"
             example:
               backfill: true
       responses:
@@ -469,7 +469,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UpdateMonitorRequestDTO"
+              $ref: "#/components/schemas/UpdateMonitorRequestDto"
             example:
               webhook:
                 url: "https://new-endpoint.com/webhook"
@@ -808,7 +808,7 @@ paths:
         Use semicolons (`;`) to separate multiple values in `alternative_names` and `key_persons`. Rows with empty `name` are skipped and reported in `validation_report`. 
 
         **Note**: The response shape differs from the JSON dataset creation endpoint: it returns `dataset_id` (not `id`) and includes a `validation_report` with details on skipped rows.
-      operationId: createDatasetFromCSV
+      operationId: createDatasetFromCsv
       requestBody:
         required: true
         content:
@@ -833,7 +833,7 @@ paths:
                   example: Companies from Q1 2026 watchlist
       responses:
         "200":
-          $ref: "#/components/responses/CreateDatasetCSVResponse"
+          $ref: "#/components/responses/CreateDatasetCsvResponse"
         "403":
           $ref: "#/components/responses/ForbiddenError"
         "422":
@@ -1065,7 +1065,7 @@ paths:
                   description: The CSV file to upload.
       responses:
         "200":
-          $ref: "#/components/responses/UploadCSVToDatasetResponse"
+          $ref: "#/components/responses/UploadCsvToDatasetResponse"
         "403":
           $ref: "#/components/responses/ForbiddenError"
         "404":
@@ -1175,7 +1175,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/InitializeResponseDTO"
+            $ref: "#/components/schemas/InitializeResponseDto"
           example:
             query: "Series B funding rounds for SaaS startups"
             context: "Focus on funding amount and company name"
@@ -1214,7 +1214,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/SubmitResponseDTO"
+            $ref: "#/components/schemas/SubmitResponseDto"
           example:
             job_id: "5f0c9087-85cb-4917-b3c7-e5a5eff73a0c"
 
@@ -1223,7 +1223,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ContinueResponseDTO"
+            $ref: "#/components/schemas/ContinueResponseDto"
           example:
             job_id: "5f0c9087-85cb-4917-b3c7-e5a5eff73a0c"
             previous_limit: 10
@@ -1235,7 +1235,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/StatusResponseDTO"
+            $ref: "#/components/schemas/StatusResponseDto"
           example:
             job_id: "5f0c9087-85cb-4917-b3c7-e5a5eff73a0c"
             status: "completed"
@@ -1292,7 +1292,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/PullJobResponseDTO"
+            $ref: "#/components/schemas/PullJobResponseDto"
           example:
             job_id: "5f0c9087-85cb-4917-b3c7-e5a5eff73a0c"
             query: "Series B funding rounds for SaaS startups"
@@ -1345,7 +1345,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/CreateMonitorResponseDTO"
+            $ref: "#/components/schemas/CreateMonitorResponseDto"
           example:
             monitor_id: "7f3a8b2c-1e4d-4a5b-9c8d-6e7f8a9b0c1d"
             status: "Monitor Created Successfully"
@@ -1355,7 +1355,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/UpdateMonitorResponseDTO"
+            $ref: "#/components/schemas/UpdateMonitorResponseDto"
           example:
             monitor_id: "3fec5b07-8786-46d7-9486-d43ff67eccd4"
             status: "Monitor updated Successfully"
@@ -1394,14 +1394,14 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/PullMonitorResponseDTO"
+            $ref: "#/components/schemas/PullMonitorResponseDto"
 
     ListMonitorsResponse:
       description: List of user monitors
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ListMonitorsResponseDTO"
+            $ref: "#/components/schemas/ListMonitorsResponseDto"
           example:
             total: 3
             page: 1
@@ -1503,12 +1503,12 @@ components:
           schema:
             $ref: "#/components/schemas/DatasetListResponse"
 
-    CreateDatasetCSVResponse:
+    CreateDatasetCsvResponse:
       description: Dataset created from CSV successfully.
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/CreateDatasetCSVResponse"
+            $ref: "#/components/schemas/CreateDatasetCsvResponse"
           example:
             dataset_id: "ccabb755-afc2-4047-b84c-78d1f23d49b2"
             dataset_name: My Portfolio
@@ -1521,12 +1521,12 @@ components:
                 - row: 3
                   reason: "missing required field: name"
 
-    UploadCSVToDatasetResponse:
+    UploadCsvToDatasetResponse:
       description: Companies added to dataset from CSV successfully.
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/UploadCSVToDatasetResponse"
+            $ref: "#/components/schemas/UploadCsvToDatasetResponse"
           example:
             dataset_id: "ccabb755-afc2-4047-b84c-78d1f23d49b2"
             entities_created: 3
@@ -1599,7 +1599,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/GetPlanLimitsResponseDTO"
+            $ref: "#/components/schemas/GetPlanLimitsResponseDto"
           example:
             features:
               - name: "Jobs Concurrency"
@@ -1851,7 +1851,7 @@ components:
               description: Confidence level for the domain URL resolution.
               example: "high"
 
-    InitializeRequestDTO:
+    InitializeRequestDto:
       type: object
       required:
         - query
@@ -1864,7 +1864,7 @@ components:
         Request to get validator, enrichment, and date range suggestions for a
         query.
 
-    InitializeResponseDTO:
+    InitializeResponseDto:
       type: object
       required:
         - query
@@ -1909,7 +1909,7 @@ components:
             - "start_date must be >= 2025-01-23, your plan limited to lookback
               365 days; we modified start_date to 2025-01-23."
 
-    SubmitRequestDTO:
+    SubmitRequestDto:
       type: object
       required:
         - query
@@ -1961,7 +1961,7 @@ components:
           example:
             - "ccabb755-afc2-4047-b84c-78d1f23d49b2"
 
-    SubmitResponseDTO:
+    SubmitResponseDto:
       type: object
       required:
         - job_id
@@ -1974,7 +1974,7 @@ components:
             retrieve results.
           example: "5f0c9087-85cb-4917-b3c7-e5a5eff73a0c"
 
-    ContinueRequestDTO:
+    ContinueRequestDto:
       type: object
       required:
         - job_id
@@ -1991,7 +1991,7 @@ components:
             New record limit for continued processing. Must be greater than the previous limit. If not provided, defaults to the plan maximum.
           example: 100
 
-    ContinueResponseDTO:
+    ContinueResponseDto:
       type: object
       required:
         - job_id
@@ -2061,7 +2061,7 @@ components:
           default: false
           description: Whether this step has finished processing.
 
-    StatusResponseDTO:
+    StatusResponseDto:
       type: object
       required:
         - job_id
@@ -2150,7 +2150,7 @@ components:
           description: Masked API key that created this job.
           example: "***...a1b2"
 
-    PullJobResponseDTO:
+    PullJobResponseDto:
       type: object
       required:
         - job_id
@@ -2421,7 +2421,7 @@ components:
 
         Includes timestamps tracking when records were added and updated, and citations include job tracking.
 
-    CreateMonitorRequestDTO:
+    CreateMonitorRequestDto:
       type: object
       required:
         - reference_job_id
@@ -2442,7 +2442,7 @@ components:
             Minimum frequency depends on your plan.
           example: "every day at 12 PM UTC"
         webhook:
-          $ref: "#/components/schemas/WebhookDTO"
+          $ref: "#/components/schemas/WebhookDto"
           description:
             Optional webhook to receive notifications when jobs complete.
         limit:
@@ -2458,7 +2458,7 @@ components:
 
             If false, no gap filling occurs and the first run uses the current cron window only — the reference job's age does not matter.
 
-    WebhookDTO:
+    WebhookDto:
       type: object
       required:
         - url
@@ -2488,7 +2488,7 @@ components:
           maxItems: 2
           description: Basic auth credentials [username, password].
 
-    CreateMonitorResponseDTO:
+    CreateMonitorResponseDto:
       type: object
       required:
         - status
@@ -2502,11 +2502,11 @@ components:
           description: Creation status or error message
           example: "Monitor Created Successfully"
 
-    UpdateMonitorRequestDTO:
+    UpdateMonitorRequestDto:
       type: object
       properties:
         webhook:
-          $ref: "#/components/schemas/WebhookDTO"
+          $ref: "#/components/schemas/WebhookDto"
           description: |
             Updated webhook configuration.
         limit:
@@ -2515,7 +2515,7 @@ components:
           description: |
             Updated maximum number of records per monitor run.
 
-    UpdateMonitorResponseDTO:
+    UpdateMonitorResponseDto:
       type: object
       required:
         - monitor_id
@@ -2544,7 +2544,7 @@ components:
           description: Context provided with the reference job query.
           example: "Focus on funding amount and company name"
 
-    PullMonitorResponseDTO:
+    PullMonitorResponseDto:
       type: object
       required:
         - monitor_id
@@ -2605,7 +2605,7 @@ components:
           description: Record limit applied to this monitor's jobs.
           example: 100
 
-    ListMonitorsResponseDTO:
+    ListMonitorsResponseDto:
       type: object
       required:
         - total
@@ -2633,10 +2633,10 @@ components:
         monitors:
           type: array
           items:
-            $ref: "#/components/schemas/MonitorListItemDTO"
+            $ref: "#/components/schemas/MonitorListItemDto"
           description: Array of monitor summaries.
 
-    MonitorListItemDTO:
+    MonitorListItemDto:
       type: object
       required:
         - monitor_id
@@ -2681,7 +2681,7 @@ components:
           example: "2025-10-23T14:30:00Z"
         webhook:
           oneOf:
-            - $ref: "#/components/schemas/WebhookDTO"
+            - $ref: "#/components/schemas/WebhookDto"
             - type: "null"
           description:
             Webhook configuration for this monitor, or null if not set.
@@ -2763,7 +2763,7 @@ components:
             on monitor schedule) in ISO 8601 format with UTC timezone.
           example: "2025-11-15T00:00:00Z"
 
-    EnableMonitorRequestDTO:
+    EnableMonitorRequestDto:
       type: object
       description: Optional request body for enabling a monitor.
       properties:
@@ -3294,7 +3294,7 @@ components:
           description: Human-readable explanation of why the row was skipped.
           example: "missing required field: name"
 
-    CreateDatasetCSVResponse:
+    CreateDatasetCsvResponse:
       type: object
       required:
         - dataset_id
@@ -3318,7 +3318,7 @@ components:
         validation_report:
           $ref: "#/components/schemas/ValidationReport"
 
-    UploadCSVToDatasetResponse:
+    UploadCsvToDatasetResponse:
       type: object
       required:
         - dataset_id
@@ -3480,7 +3480,7 @@ components:
             "Lucid Gravity is positioned as a direct competitor to the Tesla
             Model X."
 
-    GetPlanLimitsResponseDTO:
+    GetPlanLimitsResponseDto:
       type: object
       required:
         - features

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -1449,6 +1449,157 @@ components:
                   method: "POST"
                 user_key: "***...a1b2"
 
+    CreateEntityResponse:
+      description: Entity created successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CreateEntityResponse"
+          example:
+            id: "854198fa-f702-49db-a381-0427fa87f173"
+            status: pending
+
+    EntityResponse:
+      description: Entity details.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/EntityResponse"
+          example:
+            id: "854198fa-f702-49db-a381-0427fa87f173"
+            entity_type: company
+            organization_id: "e5d9e9b0-e415-4941-8ef0-916c5ee56207"
+            name: NewsCatcher
+            description: AI-powered news data provider
+            additional_attributes:
+              company_attributes:
+                domain: newscatcherapi.com
+                description: Provider of news and web search APIs for developers
+                key_persons:
+                  - Artem Bugara
+                  - Maksym Sugonyaka
+                alternative_names:
+                  - NC
+                  - NewsCatcher API
+            status: ready
+            created_by_user_id: "870e258e-12ec-4a47-8656-e7a43b0265b3"
+            created_at: "2026-04-08T15:21:17.272139"
+            updated_at: "2026-04-08T15:21:18.248316"
+
+    EntityListResponse:
+      description: Paginated list of entities.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/EntityListResponse"
+
+    CreateEntitiesBatchResponse:
+      description: Batch of entities created successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CreateEntitiesBatchResponse"
+          example:
+            entities:
+              - id: "88430468-d784-485d-84d5-6964a29ccd1e"
+                status: pending
+              - id: "ad4908fe-6db5-4237-a137-68dd8fc9fedc"
+                status: pending
+            count: 2
+
+    DatasetResponse:
+      description: Dataset details.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/DatasetResponse"
+          example:
+            id: "ccabb755-afc2-4047-b84c-78d1f23d49b2"
+            organization_id: "e5d9e9b0-e415-4941-8ef0-916c5ee56207"
+            name: My Portfolio
+            description: Companies in our investment portfolio
+            entity_count: 4
+            latest_status: ready
+            created_by_user_id: "870e258e-12ec-4a47-8656-e7a43b0265b3"
+            created_at: "2026-04-08T15:21:36.026993"
+            updated_at: "2026-04-08T15:21:36.027001"
+
+    DatasetListResponse:
+      description: Paginated list of datasets.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/DatasetListResponse"
+
+    CreateDatasetCSVResponse:
+      description: Dataset created from CSV successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CreateDatasetCSVResponse"
+          example:
+            dataset_id: "ccabb755-afc2-4047-b84c-78d1f23d49b2"
+            dataset_name: My Portfolio
+            entities_created: 3
+            validation_report:
+              total_rows: 4
+              valid_rows: 3
+              skipped_count: 1
+              skipped_rows:
+                - row: 3
+                  reason: "missing required field: name"
+
+    UploadCSVToDatasetResponse:
+      description: Companies added to dataset from CSV successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/UploadCSVToDatasetResponse"
+          example:
+            dataset_id: "ccabb755-afc2-4047-b84c-78d1f23d49b2"
+            entities_created: 3
+            validation_report:
+              total_rows: 3
+              valid_rows: 3
+              skipped_count: 0
+              skipped_rows: []
+
+    ManageEntitiesResponse:
+      description: Entities added or removed successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ManageEntitiesResponse"
+          example:
+            dataset_id: "ccabb755-afc2-4047-b84c-78d1f23d49b2"
+            affected_count: 1
+
+    DatasetEntityListResponse:
+      description: Paginated list of entities in a dataset.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/DatasetEntityListResponse"
+
+    DatasetStatusHistoryResponse:
+      description: Dataset status change history.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/DatasetStatusHistoryResponse"
+          example:
+            dataset_id: "ccabb755-afc2-4047-b84c-78d1f23d49b2"
+            history:
+              - status: pending
+                additional_information: null
+                created_at: "2026-04-08T15:21:36.066271"
+              - status: enriching
+                additional_information: null
+                created_at: "2026-04-08T15:21:36.500000"
+              - status: ready
+                additional_information: null
+                created_at: "2026-04-08T15:21:55.000000"
+
     HealthCheckResponse:
       description: API is healthy
       content:
@@ -1517,6 +1668,38 @@ components:
                 detail:
                   "New limit must be greater than the previous limit for this
                   job."
+
+    EntityBadRequestError:
+      description: |
+        Validation error in entity field values.
+
+        Returned when required fields are missing or field values are invalid
+        (for example, an unrecognised `entity_type` value). The response body
+        uses a `message`/`status`/`status_code` structure, distinct from the
+        standard `detail`-based error format used elsewhere in the API.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/EntityValidationErrorBody"
+          examples:
+            missing_name:
+              summary: Required field missing
+              value:
+                message:
+                  "Validation Error with the following fields: [{'field':
+                  'body.name', 'message': 'field required', 'type':
+                  'value_error.missing'}]"
+                status: Bad Request
+                status_code: 400
+            invalid_entity_type:
+              summary: Invalid enum value
+              value:
+                message:
+                  'Validation Error with the following fields: [{''field'':
+                  ''body.entity_type'', ''message'': "entity_type must be one of
+                  (''company'', ''person'')", ''type'': ''value_error''}]'
+                status: Bad Request
+                status_code: 400
 
     ForbiddenError:
       description: Invalid or missing API key

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -1177,6 +1177,26 @@ components:
       description: |
         Number of records per page.
 
+    EntityId:
+      name: entity_id
+      in: path
+      required: true
+      description: Unique entity identifier.
+      schema:
+        type: string
+        format: uuid
+      example: "854198fa-f702-49db-a381-0427fa87f173"
+
+    DatasetId:
+      name: dataset_id
+      in: path
+      required: true
+      description: Unique dataset identifier.
+      schema:
+        type: string
+        format: uuid
+      example: "ccabb755-afc2-4047-b84c-78d1f23d49b2"
+
   responses:
     InitializeResponse:
       description: Suggestions retrieved successfully

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -522,25 +522,21 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/EntityStatus"
-          description: Filter by entity status.
         - name: entity_type
           in: query
           required: false
           schema:
             $ref: "#/components/schemas/EntityType"
-          description: Filter by entity type.
         - name: sort_by
           in: query
           required: false
           schema:
             $ref: "#/components/schemas/EntitySortBy"
-          description: Field to sort by. Defaults to `created_at`.
         - name: sort_order
           in: query
           required: false
           schema:
             $ref: "#/components/schemas/SortOrder"
-          description: Sort direction. Defaults to `desc`.
       responses:
         "200":
           $ref: "#/components/responses/EntityListResponse"
@@ -558,9 +554,6 @@ paths:
         enrichment completes. Provide as much identifying information as
         possible — `domain` is the highest-signal field because it is
         unambiguous.
-
-        Only `name` is required. All other fields are optional but improve
-        matching quality.
       operationId: createEntity
       requestBody:
         required: true
@@ -659,12 +652,7 @@ paths:
         - Entities
       summary: Update entity
       description: |
-        Updates one or more fields of an existing entity. All fields are
-        optional — fields not included in the request body are left unchanged.
-
-        **Note:** when updating `additional_attributes.company_attributes`,
-        the provided object replaces the existing `company_attributes` in
-        full. Include all attribute fields you want to retain.
+        Updates one or more fields of an existing entity.
       operationId: updateEntity
       parameters:
         - $ref: "#/components/parameters/EntityId"
@@ -754,13 +742,11 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/DatasetSortBy"
-          description: Field to sort by. Defaults to `created_at`.
         - name: sort_order
           in: query
           required: false
           schema:
             $ref: "#/components/schemas/SortOrder"
-          description: Sort direction. Defaults to `desc`.
       responses:
         "200":
           $ref: "#/components/responses/DatasetListResponse"
@@ -1460,7 +1446,7 @@ components:
             status: pending
 
     EntityResponse:
-      description: Entity details.
+      description: Full entity object with all attributes and metadata.
       content:
         application/json:
           schema:
@@ -2920,18 +2906,13 @@ components:
     CompanyAttributes:
       type: object
       description: |
-        Identifying attributes for a company entity. All fields are optional
-        but improve matching quality.
-
-        `domain` is the highest-signal field because it is unambiguous.
-        `alternative_names` helps resolve common abbreviations and aliases.
-        `key_persons` improves recall for articles that mention people rather
-        than the company name directly.
+        Identifying attributes for a company entity. All fields are optional but improve matching quality.
       properties:
         domain:
           type: ["string", "null"]
           description: |
             Company website domain without protocol or trailing slash.
+
             The most reliable identifier — strongly recommended when available.
           example: newscatcherapi.com
         description:
@@ -2943,9 +2924,7 @@ components:
           items:
             type: string
           description: |
-            Names of key people associated with the company (founders,
-            executives, etc.). Improves matching for articles that mention
-            people rather than the company name.
+            Names of key people associated with the company (founders, executives, etc.). Improves matching for articles that mention people rather than the company name.
           example:
             - Artem Bugara
             - Maksym Sugonyaka
@@ -2954,8 +2933,7 @@ components:
           items:
             type: string
           description: |
-            Alternative names, abbreviations, or aliases. Helps resolve
-            common variations of the company name.
+            Alternative names, abbreviations, or aliases. Helps resolve common variations of the company name.
           example:
             - NC
             - NewsCatcher API
@@ -2986,8 +2964,7 @@ components:
         description:
           type: string
           description: |
-            Free-text description of the entity used for disambiguation
-            when similar names exist.
+            Free-text description of the entity used for disambiguation when similar names exist.
           example: AI-powered news data provider
         additional_attributes:
           $ref: "#/components/schemas/AdditionalAttributes"
@@ -2995,13 +2972,9 @@ components:
     UpdateEntityRequest:
       type: object
       description: |
-        Request body for updating an entity. All fields are optional — only
-        fields included in the request are updated. Fields not included are
-        left unchanged.
+        Request body for updating an entity. All fields are optional — only fields included in the request are updated. Fields not included are left unchanged.
 
-        When updating `additional_attributes.company_attributes`, the
-        provided object replaces the existing company attributes in full.
-        Include all attribute fields you want to retain.
+        **Note**: When updating `additional_attributes.company_attributes`, the provided object replaces the existing company attributes in full. Include all attribute fields you want to retain.
       properties:
         name:
           type: string
@@ -3019,7 +2992,6 @@ components:
       required:
         - id
         - status
-      description: Response returned immediately after entity creation.
       properties:
         id:
           type: string
@@ -3029,8 +3001,7 @@ components:
         status:
           type: string
           description: |
-            Initial status of the entity. Always `pending` immediately
-            after creation — enrichment happens asynchronously.
+            Initial status of the entity. Always `pending` immediately after creation — enrichment happens asynchronously.
           example: pending
 
     EntityResponse:
@@ -3041,7 +3012,6 @@ components:
         - organization_id
         - name
         - status
-      description: Full entity object with all attributes and metadata.
       properties:
         id:
           type: string
@@ -3076,15 +3046,13 @@ components:
           type: string
           format: date-time
           description: |
-            ISO 8601 timestamp of when the entity was created. Returned
-            without timezone offset (server-local time).
+            ISO 8601 timestamp of when the entity was created. Returned without timezone offset (server-local time).
           example: "2026-04-08T15:21:17.272139"
         updated_at:
           type: string
           format: date-time
           description: |
-            ISO 8601 timestamp of when the entity was last updated. Returned
-            without timezone offset (server-local time).
+            ISO 8601 timestamp of when the entity was last updated. Returned without timezone offset (server-local time).
           example: "2026-04-08T15:21:18.248316"
 
     CreateEntitiesBatchRequest:
@@ -3113,7 +3081,6 @@ components:
             $ref: "#/components/schemas/CreateEntityResponse"
           description: |
             Array of created entity stubs in the same order as the input.
-            Each item contains only the `id` and initial `status`.
         count:
           type: integer
           description: Total number of entities created.
@@ -3264,15 +3231,13 @@ components:
           type: string
           format: date-time
           description: |
-            ISO 8601 timestamp of when the dataset was created. Returned
-            without timezone offset (server-local time).
+            ISO 8601 timestamp of when the dataset was created. Returned without timezone offset (server-local time).
           example: "2026-04-08T15:21:36.026993"
         updated_at:
           type: string
           format: date-time
           description: |
-            ISO 8601 timestamp of when the dataset was last updated. Returned
-            without timezone offset (server-local time).
+            ISO 8601 timestamp of when the dataset was last updated. Returned without timezone offset (server-local time).
           example: "2026-04-08T15:21:38.401148"
 
     DatasetListResponse:
@@ -3489,8 +3454,7 @@ components:
           type: string
           format: date-time
           description: |
-            ISO 8601 timestamp of when this status was set. Returned
-            without timezone offset (server-local time).
+            ISO 8601 timestamp of when this status was set. Returned without timezone offset (server-local time).
           example: "2026-04-08T15:21:36.066271"
 
     # ── Company Search output schema ──────────────────────────────────────────

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -60,6 +60,26 @@ tags:
         Automate recurring queries with scheduled jobs and webhook
         notifications.
       url: https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/monitors
+  - name: Entities
+    description: |
+      Operations to create, update, and delete company entities.
+
+      Entities are the building blocks of Company Search. Each entity represents
+      a company (or person) you want to track. Add identifying information such as
+      domain, alternative names, and key persons to improve matching quality.
+    externalDocs:
+      description: Learn about Company Search and entities
+      url: https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/company-search
+  - name: Datasets
+    description: |
+      Operations to create and manage datasets of entities.
+
+      A dataset is a named collection of entities — think of it as a watchlist or
+      portfolio. Connect a dataset to a job via `connected_dataset_ids` to activate
+      Company Search mode. Datasets can be reused across multiple jobs and monitors.
+    externalDocs:
+      description: Learn about datasets and Company Search
+      url: https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/company-search
   - name: Meta
     description: Operations to check API health and version.
 

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -2782,6 +2782,743 @@ components:
 
             If false, no gap filling occurs and the first run uses the current cron window only — the last job's age does not matter.
 
+    # ── Shared ────────────────────────────────────────────────────────────────
+
+    SortOrder:
+      type: string
+      enum:
+        - asc
+        - desc
+      description: |
+        Sort direction for list results.
+
+        - `asc`: ascending (oldest or smallest first)
+        - `desc`: descending (newest or largest first)
+      default: desc
+
+    # ── Entity enumerations ───────────────────────────────────────────────────
+
+    EntityStatus:
+      type: string
+      enum:
+        - pending
+        - enriching
+        - ready
+        - failed
+      description: |
+        Processing status of an entity.
+
+        - `pending`: Entity has been created and is queued for enrichment.
+        - `enriching`: Enrichment is in progress.
+        - `ready`: Enrichment complete — entity is indexed and ready for use in jobs.
+        - `failed`: Enrichment failed. The entity may still be used but matching quality may be reduced.
+
+    EntityType:
+      type: string
+      enum:
+        - company
+        - person
+      description: |
+        The type of entity.
+
+        - `company`: A company or organization (default).
+        - `person`: An individual person.
+      default: company
+
+    EntitySortBy:
+      type: string
+      enum:
+        - created_at
+        - name
+        - status
+      description: Fields available for sorting entity list results.
+      default: created_at
+
+    # ── Dataset enumerations ──────────────────────────────────────────────────
+
+    DatasetStatus:
+      type: string
+      enum:
+        - pending
+        - enriching
+        - ready
+        - failed
+      description: |
+        Processing status of a dataset.
+
+        - `pending`: Dataset created, entities queued for enrichment.
+        - `enriching`: Entities are being enriched.
+        - `ready`: All entities enriched and indexed — ready for use in jobs.
+        - `failed`: One or more entity enrichments failed.
+
+    DatasetSortBy:
+      type: string
+      enum:
+        - name
+        - created_at
+        - status
+      description: Fields available for sorting dataset list results.
+      default: created_at
+
+    # ── Error schemas ─────────────────────────────────────────────────────────
+
+    EntityValidationErrorBody:
+      type: object
+      required:
+        - message
+        - status
+        - status_code
+      description: |
+        Error body returned by entity endpoints for field-level validation
+        failures. Uses a different structure from the standard `Error` schema
+        (`{"detail": "..."}`) used elsewhere in the API.
+      properties:
+        message:
+          type: string
+          description: |
+            Human-readable description of all validation errors, including
+            field path, failure message, and error type.
+          example:
+            'Validation Error with the following fields: [{''field'':
+            ''body.entity_type'', ''message'': "entity_type must be one of
+            (''company'', ''person'')", ''type'': ''value_error''}]'
+        status:
+          type: string
+          description: HTTP status text.
+          example: Bad Request
+        status_code:
+          type: integer
+          description: HTTP status code.
+          example: 400
+
+    # ── Entity request/response schemas ──────────────────────────────────────
+
+    CompanyAttributes:
+      type: object
+      description: |
+        Identifying attributes for a company entity. All fields are optional
+        but improve matching quality.
+
+        `domain` is the highest-signal field because it is unambiguous.
+        `alternative_names` helps resolve common abbreviations and aliases.
+        `key_persons` improves recall for articles that mention people rather
+        than the company name directly.
+      properties:
+        domain:
+          type: ["string", "null"]
+          description: |
+            Company website domain without protocol or trailing slash.
+            The most reliable identifier — strongly recommended when available.
+          example: newscatcherapi.com
+        description:
+          type: ["string", "null"]
+          description: Detailed description of the company used for matching.
+          example: Provider of news and web search APIs for developers
+        key_persons:
+          type: ["array", "null"]
+          items:
+            type: string
+          description: |
+            Names of key people associated with the company (founders,
+            executives, etc.). Improves matching for articles that mention
+            people rather than the company name.
+          example:
+            - Artem Bugara
+            - Maksym Sugonyaka
+        alternative_names:
+          type: ["array", "null"]
+          items:
+            type: string
+          description: |
+            Alternative names, abbreviations, or aliases. Helps resolve
+            common variations of the company name.
+          example:
+            - NC
+            - NewsCatcher API
+
+    AdditionalAttributes:
+      type: object
+      description: Additional attributes for the entity, keyed by entity type.
+      properties:
+        company_attributes:
+          $ref: "#/components/schemas/CompanyAttributes"
+
+    CreateEntityRequest:
+      type: object
+      required:
+        - name
+      description: |
+        Request body for creating a single entity. Only `name` is required.
+        The more fields you provide, the better the matching quality.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description:
+            The company or person name. Required and must be non-empty.
+          example: NewsCatcher
+        entity_type:
+          $ref: "#/components/schemas/EntityType"
+        description:
+          type: string
+          description: |
+            Free-text description of the entity used for disambiguation
+            when similar names exist.
+          example: AI-powered news data provider
+        additional_attributes:
+          $ref: "#/components/schemas/AdditionalAttributes"
+
+    UpdateEntityRequest:
+      type: object
+      description: |
+        Request body for updating an entity. All fields are optional — only
+        fields included in the request are updated. Fields not included are
+        left unchanged.
+
+        When updating `additional_attributes.company_attributes`, the
+        provided object replaces the existing company attributes in full.
+        Include all attribute fields you want to retain.
+      properties:
+        name:
+          type: string
+          description: Updated entity name.
+          example: NewsCatcher Inc.
+        description:
+          type: string
+          description: Updated description.
+          example: Updated description
+        additional_attributes:
+          $ref: "#/components/schemas/AdditionalAttributes"
+
+    CreateEntityResponse:
+      type: object
+      required:
+        - id
+        - status
+      description: Response returned immediately after entity creation.
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier of the created entity.
+          example: "854198fa-f702-49db-a381-0427fa87f173"
+        status:
+          type: string
+          description: |
+            Initial status of the entity. Always `pending` immediately
+            after creation — enrichment happens asynchronously.
+          example: pending
+
+    EntityResponse:
+      type: object
+      required:
+        - id
+        - entity_type
+        - organization_id
+        - name
+        - status
+      description: Full entity object with all attributes and metadata.
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier of the entity.
+          example: "854198fa-f702-49db-a381-0427fa87f173"
+        entity_type:
+          $ref: "#/components/schemas/EntityType"
+        organization_id:
+          type: string
+          format: uuid
+          description: Organization that owns this entity.
+          example: "e5d9e9b0-e415-4941-8ef0-916c5ee56207"
+        name:
+          type: string
+          description: Entity name.
+          example: NewsCatcher
+        description:
+          type: ["string", "null"]
+          description: Free-text description.
+          example: AI-powered news data provider
+        additional_attributes:
+          $ref: "#/components/schemas/AdditionalAttributes"
+        status:
+          $ref: "#/components/schemas/EntityStatus"
+        created_by_user_id:
+          type: string
+          format: uuid
+          description: ID of the user who created this entity.
+          example: "870e258e-12ec-4a47-8656-e7a43b0265b3"
+        created_at:
+          type: string
+          format: date-time
+          description: |
+            ISO 8601 timestamp of when the entity was created. Returned
+            without timezone offset (server-local time).
+          example: "2026-04-08T15:21:17.272139"
+        updated_at:
+          type: string
+          format: date-time
+          description: |
+            ISO 8601 timestamp of when the entity was last updated. Returned
+            without timezone offset (server-local time).
+          example: "2026-04-08T15:21:18.248316"
+
+    CreateEntitiesBatchRequest:
+      type: object
+      required:
+        - entities
+      properties:
+        entities:
+          type: array
+          items:
+            $ref: "#/components/schemas/CreateEntityRequest"
+          description: |
+            Array of entities to create. Each item follows the same schema
+            as single entity creation.
+          minItems: 1
+
+    CreateEntitiesBatchResponse:
+      type: object
+      required:
+        - entities
+        - count
+      properties:
+        entities:
+          type: array
+          items:
+            $ref: "#/components/schemas/CreateEntityResponse"
+          description: |
+            Array of created entity stubs in the same order as the input.
+            Each item contains only the `id` and initial `status`.
+        count:
+          type: integer
+          description: Total number of entities created.
+          example: 3
+
+    EntityListResponse:
+      type: object
+      required:
+        - entities
+        - total
+        - page
+        - page_size
+      properties:
+        entities:
+          type: array
+          items:
+            $ref: "#/components/schemas/EntityResponse"
+          description: Array of entity objects for this page.
+        total:
+          type: integer
+          description: Total number of entities matching the filter criteria.
+          example: 17
+        page:
+          type: integer
+          description: Current page number.
+          example: 1
+        page_size:
+          type: integer
+          description: Number of entities per page.
+          example: 100
+
+    EntitySummary:
+      type: object
+      required:
+        - id
+        - name
+        - entity_type
+        - status
+      description: |
+        Abbreviated entity object returned when listing entities within a
+        dataset. Uses a flat `attributes` key rather than the nested
+        `additional_attributes.company_attributes` structure used in
+        standalone entity endpoints.
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier of the entity.
+          example: "854198fa-f702-49db-a381-0427fa87f173"
+        name:
+          type: string
+          description: Entity name.
+          example: NewsCatcher
+        entity_type:
+          $ref: "#/components/schemas/EntityType"
+        status:
+          $ref: "#/components/schemas/EntityStatus"
+        description:
+          type: ["string", "null"]
+          description: Free-text description.
+          example: AI-powered news data provider
+        attributes:
+          $ref: "#/components/schemas/CompanyAttributes"
+
+    # ── Dataset request/response schemas ──────────────────────────────────────
+
+    CreateDatasetRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: Name for the dataset.
+          example: My Portfolio
+        description:
+          type: string
+          description: Optional description.
+          example: Companies in our investment portfolio
+        entity_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: |
+            IDs of existing entities to include in the dataset. All IDs
+            must belong to the authenticated organization. If any ID is
+            invalid or not found, the request fails with `400`.
+          example:
+            - "854198fa-f702-49db-a381-0427fa87f173"
+            - "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+    UpdateDatasetRequest:
+      type: object
+      description: |
+        Updates dataset name or description. At least one field should be
+        provided.
+      properties:
+        name:
+          type: string
+          description: Updated dataset name.
+          example: My Portfolio (updated)
+        description:
+          type: string
+          description: Updated description.
+          example: Updated description
+
+    DatasetResponse:
+      type: object
+      required:
+        - id
+        - organization_id
+        - name
+      description: Full dataset object with metadata and current status.
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier of the dataset.
+          example: "ccabb755-afc2-4047-b84c-78d1f23d49b2"
+        organization_id:
+          type: string
+          format: uuid
+          description: Organization that owns this dataset.
+          example: "e5d9e9b0-e415-4941-8ef0-916c5ee56207"
+        name:
+          type: string
+          description: Dataset name.
+          example: My Portfolio
+        description:
+          type: ["string", "null"]
+          description: Optional description.
+          example: Companies in our investment portfolio
+        entity_count:
+          type: integer
+          description: Total number of entities in this dataset.
+          default: 0
+          example: 4
+        latest_status:
+          $ref: "#/components/schemas/DatasetStatus"
+        created_by_user_id:
+          type: string
+          format: uuid
+          description: ID of the user who created this dataset.
+          example: "870e258e-12ec-4a47-8656-e7a43b0265b3"
+        created_at:
+          type: string
+          format: date-time
+          description: |
+            ISO 8601 timestamp of when the dataset was created. Returned
+            without timezone offset (server-local time).
+          example: "2026-04-08T15:21:36.026993"
+        updated_at:
+          type: string
+          format: date-time
+          description: |
+            ISO 8601 timestamp of when the dataset was last updated. Returned
+            without timezone offset (server-local time).
+          example: "2026-04-08T15:21:38.401148"
+
+    DatasetListResponse:
+      type: object
+      required:
+        - datasets
+        - total
+        - page
+        - page_size
+      properties:
+        datasets:
+          type: array
+          items:
+            $ref: "#/components/schemas/DatasetResponse"
+          description: Array of dataset objects for this page.
+        total:
+          type: integer
+          description: Total number of datasets matching the filter criteria.
+          example: 5
+        page:
+          type: integer
+          description: Current page number.
+          example: 1
+        page_size:
+          type: integer
+          description: Number of datasets per page.
+          example: 100
+
+    ValidationReport:
+      type: object
+      required:
+        - total_rows
+        - valid_rows
+        - skipped_count
+        - skipped_rows
+      description: Summary of CSV processing results.
+      properties:
+        total_rows:
+          type: integer
+          description: |
+            Total number of data rows in the uploaded CSV (excluding the
+            header row).
+          example: 4
+        valid_rows:
+          type: integer
+          description: Number of rows successfully processed into entities.
+          example: 3
+        skipped_count:
+          type: integer
+          description: Number of rows skipped due to validation errors.
+          example: 1
+        skipped_rows:
+          type: array
+          items:
+            $ref: "#/components/schemas/SkippedRow"
+          description: Details for each skipped row.
+
+    SkippedRow:
+      type: object
+      required:
+        - row
+        - reason
+      description: Details about a CSV row that was skipped during processing.
+      properties:
+        row:
+          type: integer
+          description: |
+            1-based row number in the CSV file (including the header row).
+            A value of `3` means the third line of the file (second data row).
+          example: 3
+        reason:
+          type: string
+          description: Human-readable explanation of why the row was skipped.
+          example: "missing required field: name"
+
+    CreateDatasetCSVResponse:
+      type: object
+      required:
+        - dataset_id
+        - dataset_name
+        - entities_created
+        - validation_report
+      description: |
+        Response from creating a new dataset via CSV upload. Uses
+        `dataset_id` (not `id`) and `dataset_name` (not `name`), unlike
+        the JSON-based dataset creation response.
+      properties:
+        dataset_id:
+          type: string
+          format: uuid
+          description: Unique identifier of the created dataset.
+          example: "ccabb755-afc2-4047-b84c-78d1f23d49b2"
+        dataset_name:
+          type: string
+          description: Name of the created dataset.
+          example: My Portfolio
+        entities_created:
+          type: integer
+          description: Number of entities successfully created from the CSV.
+          example: 3
+        validation_report:
+          $ref: "#/components/schemas/ValidationReport"
+
+    UploadCSVToDatasetResponse:
+      type: object
+      required:
+        - dataset_id
+        - entities_created
+        - validation_report
+      description: |
+        Response from adding companies to an existing dataset via CSV upload.
+        Same shape as `CreateDatasetCSVResponse` but without `dataset_name`.
+      properties:
+        dataset_id:
+          type: string
+          format: uuid
+          description: ID of the dataset that was updated.
+          example: "ccabb755-afc2-4047-b84c-78d1f23d49b2"
+        entities_created:
+          type: integer
+          description: Number of new entities created from the CSV.
+          example: 3
+        validation_report:
+          $ref: "#/components/schemas/ValidationReport"
+
+    DatasetEntityIdsRequest:
+      type: object
+      required:
+        - entity_ids
+      properties:
+        entity_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: List of entity IDs to add or remove.
+          minItems: 1
+          example:
+            - "854198fa-f702-49db-a381-0427fa87f173"
+
+    ManageEntitiesResponse:
+      type: object
+      required:
+        - dataset_id
+        - affected_count
+      description: Result of adding or removing entities from a dataset.
+      properties:
+        dataset_id:
+          type: string
+          format: uuid
+          description: ID of the dataset that was modified.
+          example: "ccabb755-afc2-4047-b84c-78d1f23d49b2"
+        affected_count:
+          type: integer
+          description: Number of entities that were added or removed.
+          example: 1
+
+    DatasetEntityListResponse:
+      type: object
+      required:
+        - entities
+        - total
+        - page
+        - page_size
+      properties:
+        entities:
+          type: array
+          items:
+            $ref: "#/components/schemas/EntitySummary"
+          description: Array of entity summary objects for this page.
+        total:
+          type: integer
+          description: Total number of entities in the dataset.
+          example: 4
+        page:
+          type: integer
+          description: Current page number.
+          example: 1
+        page_size:
+          type: integer
+          description: Number of entities per page.
+          example: 100
+
+    DatasetStatusHistoryResponse:
+      type: object
+      required:
+        - dataset_id
+        - history
+      properties:
+        dataset_id:
+          type: string
+          format: uuid
+          description: ID of the dataset.
+          example: "ccabb755-afc2-4047-b84c-78d1f23d49b2"
+        history:
+          type: array
+          items:
+            $ref: "#/components/schemas/DatasetStatusEntry"
+          description: Status change entries, ordered oldest to newest.
+
+    DatasetStatusEntry:
+      type: object
+      required:
+        - status
+      description: A single status change event in a dataset's history.
+      properties:
+        status:
+          $ref: "#/components/schemas/DatasetStatus"
+        additional_information:
+          type: ["object", "null"]
+          description: Additional context about the status change, if available.
+          example: null
+        created_at:
+          type: string
+          format: date-time
+          description: |
+            ISO 8601 timestamp of when this status was set. Returned
+            without timezone offset (server-local time).
+          example: "2026-04-08T15:21:36.066271"
+
+    # ── Company Search output schema ──────────────────────────────────────────
+
+    ConnectedEntity:
+      type: object
+      required:
+        - entity_id
+        - name
+        - ed_score
+        - relation
+      description: |
+        A company entity matched to a record in a Company Search job, with
+        a relevance score and explanation.
+
+        Only entities with `ed_score` ≥ 1 appear in results. Entities scored
+        0 are filtered out before the response is returned.
+      properties:
+        entity_id:
+          type: string
+          format: uuid
+          description: Unique identifier of the matched entity.
+          example: "e1f2a3b4-c5d6-7890-abcd-ef1234567890"
+        name:
+          type: string
+          description: Name of the matched entity.
+          example: Tesla
+        ed_score:
+          type: integer
+          minimum: 1
+          maximum: 10
+          description: |
+            Relevance score indicating how directly the entity is associated
+            with this event.
+
+            | Score | Meaning |
+            |-------|---------|
+            | 10 | Direct mention, critical event (merger, CEO change, major lawsuit) |
+            | 7–9 | Major impact (earnings, product launch, senior hire) |
+            | 4–6 | Routine update (minor product news, mid-level changes) |
+            | 1–3 | Indirect mention (listed with others, stock noise) |
+          example: 8
+        relation:
+          type: string
+          maxLength: 100
+          description: |
+            Short explanation (up to 100 characters) of why this entity is
+            associated with the event.
+          example:
+            "Lucid Gravity is positioned as a direct competitor to the Tesla
+            Model X."
+
     GetPlanLimitsResponseDTO:
       type: object
       required:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -488,7 +488,7 @@ paths:
 
   # ── Entities ──────────────────────────────────────────────────────────────
 
-  /catchAll/entities/:
+  /catchAll/entities:
     get:
       tags:
         - Entities
@@ -712,43 +712,7 @@ paths:
 
   # ── Datasets ──────────────────────────────────────────────────────────────
 
-  /catchAll/datasets/:
-    post:
-      tags:
-        - Datasets
-      summary: Create dataset
-      description: |
-        Creates a new dataset from a list of existing entity IDs.
-
-        If any of the provided entity IDs do not exist or do not belong to
-        your organization, the request fails with `400`. All entity IDs must
-        be valid before the dataset is created.
-
-        To create a dataset and entities in one step, use the CSV upload
-        endpoint instead.
-      operationId: createDataset
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreateDatasetRequest"
-            example:
-              name: My Portfolio
-              description: Companies in our investment portfolio
-              entity_ids:
-                - 854198fa-f702-49db-a381-0427fa87f173
-                - a1b2c3d4-e5f6-7890-abcd-ef1234567890
-      responses:
-        "200":
-          $ref: "#/components/responses/DatasetResponse"
-        "400":
-          $ref: "#/components/responses/BadRequestError"
-        "403":
-          $ref: "#/components/responses/ForbiddenError"
-        "422":
-          $ref: "#/components/responses/ValidationError"
-
+  /catchAll/datasets:
     get:
       tags:
         - Datasets
@@ -802,6 +766,42 @@ paths:
           $ref: "#/components/responses/DatasetListResponse"
         "403":
           $ref: "#/components/responses/ForbiddenError"
+
+    post:
+      tags:
+        - Datasets
+      summary: Create dataset
+      description: |
+        Creates a new dataset from a list of existing entity IDs.
+
+        If any of the provided entity IDs do not exist or do not belong to
+        your organization, the request fails with `400`. All entity IDs must
+        be valid before the dataset is created.
+
+        To create a dataset and entities in one step, use the CSV upload
+        endpoint instead.
+      operationId: createDataset
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateDatasetRequest"
+            example:
+              name: My Portfolio
+              description: Companies in our investment portfolio
+              entity_ids:
+                - 854198fa-f702-49db-a381-0427fa87f173
+                - a1b2c3d4-e5f6-7890-abcd-ef1234567890
+      responses:
+        "200":
+          $ref: "#/components/responses/DatasetResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
 
   /catchAll/datasets/upload:
     post:
@@ -927,65 +927,6 @@ paths:
           $ref: "#/components/responses/NotFoundError"
 
   /catchAll/datasets/{dataset_id}/entities:
-    post:
-      tags:
-        - Datasets
-      summary: Add entities to dataset
-      description: |
-        Adds one or more existing entities to a dataset. Returns the number
-        of entities added.
-      operationId: addEntitiesToDataset
-      parameters:
-        - $ref: "#/components/parameters/DatasetId"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/DatasetEntityIdsRequest"
-            example:
-              entity_ids:
-                - 854198fa-f702-49db-a381-0427fa87f173
-      responses:
-        "200":
-          $ref: "#/components/responses/ManageEntitiesResponse"
-        "403":
-          $ref: "#/components/responses/ForbiddenError"
-        "404":
-          $ref: "#/components/responses/NotFoundError"
-        "422":
-          $ref: "#/components/responses/ValidationError"
-
-    delete:
-      tags:
-        - Datasets
-      summary: Remove entities from dataset
-      description: |
-        Removes one or more entities from a dataset. The entities themselves
-        are not deleted — they are only removed from this dataset. Returns
-        the number of entities removed.
-      operationId: removeEntitiesFromDataset
-      parameters:
-        - $ref: "#/components/parameters/DatasetId"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/DatasetEntityIdsRequest"
-            example:
-              entity_ids:
-                - 854198fa-f702-49db-a381-0427fa87f173
-      responses:
-        "200":
-          $ref: "#/components/responses/ManageEntitiesResponse"
-        "403":
-          $ref: "#/components/responses/ForbiddenError"
-        "404":
-          $ref: "#/components/responses/NotFoundError"
-        "422":
-          $ref: "#/components/responses/ValidationError"
-
     get:
       tags:
         - Datasets
@@ -1044,6 +985,65 @@ paths:
           $ref: "#/components/responses/ForbiddenError"
         "404":
           $ref: "#/components/responses/NotFoundError"
+
+    post:
+      tags:
+        - Datasets
+      summary: Add entities to dataset
+      description: |
+        Adds one or more existing entities to a dataset. Returns the number
+        of entities added.
+      operationId: addEntitiesToDataset
+      parameters:
+        - $ref: "#/components/parameters/DatasetId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DatasetEntityIdsRequest"
+            example:
+              entity_ids:
+                - 854198fa-f702-49db-a381-0427fa87f173
+      responses:
+        "200":
+          $ref: "#/components/responses/ManageEntitiesResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+    delete:
+      tags:
+        - Datasets
+      summary: Remove entities from dataset
+      description: |
+        Removes one or more entities from a dataset. The entities themselves
+        are not deleted — they are only removed from this dataset. Returns
+        the number of entities removed.
+      operationId: removeEntitiesFromDataset
+      parameters:
+        - $ref: "#/components/parameters/DatasetId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DatasetEntityIdsRequest"
+            example:
+              entity_ids:
+                - 854198fa-f702-49db-a381-0427fa87f173
+      responses:
+        "200":
+          $ref: "#/components/responses/ManageEntitiesResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
 
   /catchAll/datasets/{dataset_id}/status:
     get:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -1975,6 +1975,22 @@ components:
 
             - `base`: Full pipeline with validation and enrichment.
             - `lite`: Lightweight extraction with faster processing. Returns titles and citations only.
+        connected_dataset_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: |
+            Dataset IDs to connect to this job. When provided, activates
+            Company Search mode — the job returns only events relevant to
+            companies in the connected datasets, with each record including a
+            `connected_entities` array scored per company.
+
+            The dataset must have `latest_status: ready` before the job is
+            submitted. Submitting with a non-existent or inaccessible dataset
+            ID returns `400`.
+          example:
+            - "ccabb755-afc2-4047-b84c-78d1f23d49b2"
 
     SubmitResponseDTO:
       type: object
@@ -2339,6 +2355,13 @@ components:
                 $ref: "#/components/schemas/Citation"
               description:
                 Source documents that were used to extract this record.
+            connected_entities:
+              type: array
+              items:
+                $ref: "#/components/schemas/ConnectedEntity"
+              description: |
+                Entities from the connected dataset that are relevant to this record.
+                Only present when the job was submitted with `connected_dataset_ids`.
 
     Citation:
       type: object
@@ -2426,6 +2449,7 @@ components:
               example: "2025-11-14T21:00:00Z"
       description: |
         Record with monitor-specific metadata. Used in monitor results and webhook payloads.
+
         Includes timestamps tracking when records were added and updated, and citations include job tracking.
 
     CreateMonitorRequestDTO:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -735,8 +735,7 @@ paths:
           schema:
             $ref: "#/components/schemas/DatasetStatus"
           description: |
-            Filter by dataset status. Note: the query parameter is named
-            `latest_status`, not `status`.
+            Filter by dataset status.
         - name: sort_by
           in: query
           required: false
@@ -764,7 +763,7 @@ paths:
         your organization, the request fails with `400`. All entity IDs must
         be valid before the dataset is created.
 
-        To create a dataset and entities in one step, use the CSV upload
+        To create a dataset and entities in one step, use the [`Create dataset from CSV`](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/create-dataset-from-csv)
         endpoint instead.
       operationId: createDataset
       requestBody:
@@ -800,19 +799,15 @@ paths:
         are optional.
 
         **CSV format:**
-        ```
+        ```csv
         name,description,domain,alternative_names,key_persons
         NewsCatcher,"AI-powered news data provider",newscatcherapi.com,"NC;NewsCatcher API","Artem Bugara;Maksym Sugonyaka"
         OpenAI,"Artificial intelligence research company",openai.com,"Open AI","Sam Altman"
         ```
 
-        Use semicolons (`;`) to separate multiple values in
-        `alternative_names` and `key_persons`. Rows with an empty `name`
-        field are skipped and reported in the `validation_report`.
+        Use semicolons (`;`) to separate multiple values in `alternative_names` and `key_persons`. Rows with empty `name` are skipped and reported in `validation_report`. 
 
-        The response shape differs from the JSON dataset creation endpoint:
-        it returns `dataset_id` (not `id`) and includes a `validation_report`
-        with details on any skipped rows.
+        **Note**: The response shape differs from the JSON dataset creation endpoint: it returns `dataset_id` (not `id`) and includes a `validation_report` with details on skipped rows.
       operationId: createDatasetFromCSV
       requestBody:
         required: true
@@ -868,9 +863,7 @@ paths:
         - Datasets
       summary: Update dataset
       description: |
-        Updates the name or description of a dataset. Only `name` and
-        `description` can be updated. To change the entities in a dataset,
-        use the add or remove entity endpoints.
+        Updates the name or description of a dataset.
       operationId: updateDataset
       parameters:
         - $ref: "#/components/parameters/DatasetId"
@@ -918,13 +911,7 @@ paths:
         - Datasets
       summary: List entities in dataset
       description: |
-        Returns a paginated list of entities in a dataset. Supports filtering
-        by status and entity type.
-
-        Note: entities returned here use a summary shape with a flat
-        `attributes` key rather than the nested
-        `additional_attributes.company_attributes` structure used in the
-        standalone entity endpoints.
+        Returns a paginated list of entities in a dataset. Supports filtering by status and entity type.
       operationId: listEntitiesInDataset
       parameters:
         - $ref: "#/components/parameters/DatasetId"
@@ -977,8 +964,7 @@ paths:
         - Datasets
       summary: Add entities to dataset
       description: |
-        Adds one or more existing entities to a dataset. Returns the number
-        of entities added.
+        Adds one or more existing entities to a dataset. Returns the number of entities added.
       operationId: addEntitiesToDataset
       parameters:
         - $ref: "#/components/parameters/DatasetId"
@@ -1494,7 +1480,7 @@ components:
             count: 2
 
     DatasetResponse:
-      description: Dataset details.
+      description: Full dataset object with metadata and current status.
       content:
         application/json:
           schema:
@@ -1798,7 +1784,9 @@ components:
         - `date`: ISO format dates (YYYY-MM-DD)
         - `option`: Enum-like fixed values (status, category)
         - `url`: Web URLs
-        - `company`: Structured company data. Returns `source_text`, `confidence`, and `metadata`. See [Company enrichment](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/company-enrichment-dto) data model.
+        - `company`: Structured company data. Returns `source_text`, `confidence`, and `metadata`. 
+
+        See [Company enrichment](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/company-enrichment-dto) data model.
 
     EnrichmentSchema:
       type: object
@@ -1967,14 +1955,9 @@ components:
             type: string
             format: uuid
           description: |
-            Dataset IDs to connect to this job. When provided, activates
-            Company Search mode — the job returns only events relevant to
-            companies in the connected datasets, with each record including a
-            `connected_entities` array scored per company.
+            Dataset IDs to connect to this job. When provided, activates Company Search mode — the job returns only events relevant to companies in the connected datasets with each record including a `connected_entities` array scored per company.
 
-            The dataset must have `latest_status: ready` before the job is
-            submitted. Submitting with a non-existent or inaccessible dataset
-            ID returns `400`.
+            The dataset must have `latest_status: ready` before the job is submitted. Submitting with a non-existent or inaccessible dataset ID returns `400`.
           example:
             - "ccabb755-afc2-4047-b84c-78d1f23d49b2"
 
@@ -3167,9 +3150,7 @@ components:
             type: string
             format: uuid
           description: |
-            IDs of existing entities to include in the dataset. All IDs
-            must belong to the authenticated organization. If any ID is
-            invalid or not found, the request fails with `400`.
+            IDs of existing entities to include in the dataset. All IDs must belong to the authenticated organization. If any ID is invalid or not found, the request fails with `400`.
           example:
             - "854198fa-f702-49db-a381-0427fa87f173"
             - "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
@@ -3195,7 +3176,6 @@ components:
         - id
         - organization_id
         - name
-      description: Full dataset object with metadata and current status.
       properties:
         id:
           type: string
@@ -3306,6 +3286,7 @@ components:
           type: integer
           description: |
             1-based row number in the CSV file (including the header row).
+
             A value of `3` means the third line of the file (second data row).
           example: 3
         reason:
@@ -3320,10 +3301,6 @@ components:
         - dataset_name
         - entities_created
         - validation_report
-      description: |
-        Response from creating a new dataset via CSV upload. Uses
-        `dataset_id` (not `id`) and `dataset_name` (not `name`), unlike
-        the JSON-based dataset creation response.
       properties:
         dataset_id:
           type: string
@@ -3347,9 +3324,6 @@ components:
         - dataset_id
         - entities_created
         - validation_report
-      description: |
-        Response from adding companies to an existing dataset via CSV upload.
-        Same shape as `CreateDatasetCSVResponse` but without `dataset_name`.
       properties:
         dataset_id:
           type: string
@@ -3383,7 +3357,6 @@ components:
       required:
         - dataset_id
         - affected_count
-      description: Result of adding or removing entities from a dataset.
       properties:
         dataset_id:
           type: string

--- a/web-search-api/api-reference/datasets/add-entities-to-dataset.mdx
+++ b/web-search-api/api-reference/datasets/add-entities-to-dataset.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api post /catchAll/datasets/{dataset_id}/entities
+---

--- a/web-search-api/api-reference/datasets/create-dataset-from-csv.mdx
+++ b/web-search-api/api-reference/datasets/create-dataset-from-csv.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api post /catchAll/datasets/upload
+---

--- a/web-search-api/api-reference/datasets/create-dataset.mdx
+++ b/web-search-api/api-reference/datasets/create-dataset.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: catch-all-api post /catchAll/datasets/
+openapi: catch-all-api post /catchAll/datasets
 ---

--- a/web-search-api/api-reference/datasets/create-dataset.mdx
+++ b/web-search-api/api-reference/datasets/create-dataset.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api post /catchAll/datasets/
+---

--- a/web-search-api/api-reference/datasets/delete-dataset.mdx
+++ b/web-search-api/api-reference/datasets/delete-dataset.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api delete /catchAll/datasets/{dataset_id}
+---

--- a/web-search-api/api-reference/datasets/get-dataset-status-history.mdx
+++ b/web-search-api/api-reference/datasets/get-dataset-status-history.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api get /catchAll/datasets/{dataset_id}/status
+---

--- a/web-search-api/api-reference/datasets/get-dataset.mdx
+++ b/web-search-api/api-reference/datasets/get-dataset.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api get /catchAll/datasets/{dataset_id}
+---

--- a/web-search-api/api-reference/datasets/list-datasets.mdx
+++ b/web-search-api/api-reference/datasets/list-datasets.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: catch-all-api get /catchAll/datasets/
+openapi: catch-all-api get /catchAll/datasets
 ---

--- a/web-search-api/api-reference/datasets/list-datasets.mdx
+++ b/web-search-api/api-reference/datasets/list-datasets.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api get /catchAll/datasets/
+---

--- a/web-search-api/api-reference/datasets/list-entities-in-dataset.mdx
+++ b/web-search-api/api-reference/datasets/list-entities-in-dataset.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api get /catchAll/datasets/{dataset_id}/entities
+---

--- a/web-search-api/api-reference/datasets/remove-entities-from-dataset.mdx
+++ b/web-search-api/api-reference/datasets/remove-entities-from-dataset.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api delete /catchAll/datasets/{dataset_id}/entities
+---

--- a/web-search-api/api-reference/datasets/update-dataset.mdx
+++ b/web-search-api/api-reference/datasets/update-dataset.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api patch /catchAll/datasets/{dataset_id}
+---

--- a/web-search-api/api-reference/datasets/upload-csv-to-dataset.mdx
+++ b/web-search-api/api-reference/datasets/upload-csv-to-dataset.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api post /catchAll/datasets/{dataset_id}/upload
+---

--- a/web-search-api/api-reference/entities/create-entities-batch.mdx
+++ b/web-search-api/api-reference/entities/create-entities-batch.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api post /catchAll/entities/batch
+---

--- a/web-search-api/api-reference/entities/create-entity.mdx
+++ b/web-search-api/api-reference/entities/create-entity.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api post /catchAll/entities/
+---

--- a/web-search-api/api-reference/entities/create-entity.mdx
+++ b/web-search-api/api-reference/entities/create-entity.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: catch-all-api post /catchAll/entities/
+openapi: catch-all-api post /catchAll/entities
 ---

--- a/web-search-api/api-reference/entities/delete-entity.mdx
+++ b/web-search-api/api-reference/entities/delete-entity.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api delete /catchAll/entities/{entity_id}
+---

--- a/web-search-api/api-reference/entities/get-entity.mdx
+++ b/web-search-api/api-reference/entities/get-entity.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api get /catchAll/entities/{entity_id}
+---

--- a/web-search-api/api-reference/entities/list-entities.mdx
+++ b/web-search-api/api-reference/entities/list-entities.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api get /catchAll/entities/
+---

--- a/web-search-api/api-reference/entities/list-entities.mdx
+++ b/web-search-api/api-reference/entities/list-entities.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: catch-all-api get /catchAll/entities/
+openapi: catch-all-api get /catchAll/entities
 ---

--- a/web-search-api/api-reference/entities/update-entity.mdx
+++ b/web-search-api/api-reference/entities/update-entity.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api patch /catchAll/entities/{entity_id}
+---

--- a/web-search-api/get-started/changelog.mdx
+++ b/web-search-api/get-started/changelog.mdx
@@ -5,6 +5,69 @@ description: Track updates, improvements, and fixes to the CatchAll API.
 rss: true
 ---
 
+<Update label="1.4.0" description="2026-04-14">
+## Company search
+
+Introduces company search — track specific companies across CatchAll jobs by
+connecting datasets of entities.
+
+**Features:**
+
+- **Entities**: Define companies with names, domains, alternative names, and key
+  persons.
+- **Datasets**: Group entities into reusable collections (watchlists,
+  portfolios).
+- **Connected jobs**: Submit jobs with `connected_dataset_ids` to activate
+  company search mode.
+- **Per-company scoring**: Each result record includes a `connected_entities`
+  array with `entity_id`, `name`, `ed_score`, and `relation` for each matched
+  company.
+
+**Endpoints:**
+
+- [`GET /catchAll/entities`](/web-search-api/api-reference/entities/list-entities)
+  — List entities.
+- [`POST /catchAll/entities`](/web-search-api/api-reference/entities/create-entity)
+  — Create a company entity.
+- [`POST /catchAll/entities/batch`](/web-search-api/api-reference/entities/create-entities-batch)
+  — Create multiple entities.
+- [`GET /catchAll/entities/{entity_id}`](/web-search-api/api-reference/entities/get-entity)
+  — Get entity.
+- [`PATCH /catchAll/entities/{entity_id}`](/web-search-api/api-reference/entities/update-entity)
+  — Update entity.
+- [`DELETE /catchAll/entities/{entity_id}`](/web-search-api/api-reference/entities/delete-entity)
+  — Delete entity.
+- [`GET /catchAll/datasets`](/web-search-api/api-reference/datasets/list-datasets)
+  — List datasets.
+- [`POST /catchAll/datasets`](/web-search-api/api-reference/datasets/create-dataset)
+  — Create dataset from entity IDs.
+- [`POST /catchAll/datasets/upload`](/web-search-api/api-reference/datasets/create-dataset-from-csv)
+  — Create dataset from CSV.
+- [`GET /catchAll/datasets/{dataset_id}`](/web-search-api/api-reference/datasets/get-dataset)
+  — Get dataset.
+- [`PATCH /catchAll/datasets/{dataset_id}`](/web-search-api/api-reference/datasets/update-dataset)
+  — Update dataset.
+- [`DELETE /catchAll/datasets/{dataset_id}`](/web-search-api/api-reference/datasets/delete-dataset)
+  — Delete dataset.
+- [`GET /catchAll/datasets/{dataset_id}/entities`](/web-search-api/api-reference/datasets/list-entities-in-dataset)
+  — List entities in dataset.
+- [`POST /catchAll/datasets/{dataset_id}/entities`](/web-search-api/api-reference/datasets/add-entities-to-dataset)
+  — Add entities to dataset.
+- [`DELETE /catchAll/datasets/{dataset_id}/entities`](/web-search-api/api-reference/datasets/remove-entities-from-dataset)
+  — Remove entities from dataset.
+- [`GET /catchAll/datasets/{dataset_id}/status`](/web-search-api/api-reference/datasets/get-dataset-status-history)
+  — Get dataset status history.
+- [`POST /catchAll/datasets/{dataset_id}/upload`](/web-search-api/api-reference/datasets/upload-csv-to-dataset)
+  — Add companies to dataset via CSV.
+
+**Changed:**
+
+- [`POST /catchAll/submit`](/web-search-api/api-reference/jobs/create-job) now
+  accepts `connected_dataset_ids` — an optional array of dataset UUIDs that
+  activates company search mode.
+
+</Update>
+
 <Update label="1.3.1" description="2026-03-19">
 ## Job modes, plan limits, and response improvements
 

--- a/web-search-api/get-started/introduction.mdx
+++ b/web-search-api/get-started/introduction.mdx
@@ -168,6 +168,22 @@ CatchAll processes queries through a multi-stage pipeline that analyzes over
     Continue requests preserve all analysis, validation, and extraction logic 
     from the original job.
   </Accordion>
+
+  <Accordion title="Company search" icon="building">
+    Filter job results to a predefined list of companies and receive
+    per-company relevance scores on every record. Activate by passing
+    `connected_dataset_ids` when submitting a job.
+
+    Build a dataset of company entities, then connect it to any job:
+    - Results are filtered to events relevant to your companies
+    - Each record includes a `connected_entities` array with `entity_id`,
+      `name`, `ed_score` (1–10), and `relation` for each matched company
+
+    <Tip>
+      See [Company search](/web-search-api/guides-and-concepts/company-search)
+      for a full walkthrough.
+    </Tip>
+  </Accordion>
 </AccordionGroup>
 
 ## Endpoints
@@ -202,6 +218,33 @@ CatchAll processes queries through a multi-stage pipeline that analyzes over
     | `/catchAll/monitors/pull/{monitor_id}`    | `GET `   | Get aggregated monitor results |
     | `/catchAll/monitors/{monitor_id}/enable`  | `POST`   | Enable a monitor               |
     | `/catchAll/monitors/{monitor_id}/disable` | `POST`   | Disable a monitor              |
+  </Tab>
+
+  <Tab title="Entities">
+    | Endpoint                              | Method   | Description                        |
+    | ------------------------------------- | -------- | ---------------------------------- |
+    | `/catchAll/entities`                  | `POST`   | Create a company entity            |
+    | `/catchAll/entities/batch`            | `POST`   | Create multiple entities           |
+    | `/catchAll/entities`                  | `GET`    | List entities                      |
+    | `/catchAll/entities/{entity_id}`      | `GET`    | Get entity                         |
+    | `/catchAll/entities/{entity_id}`      | `PATCH`  | Update entity                      |
+    | `/catchAll/entities/{entity_id}`      | `DELETE` | Delete entity                      |
+  </Tab>
+
+  <Tab title="Datasets">
+    | Endpoint                                        | Method   | Description                              |
+    | ----------------------------------------------- | -------- | ---------------------------------------- |
+    | `/catchAll/datasets`                            | `POST`   | Create dataset from entity IDs           |
+    | `/catchAll/datasets/upload`                     | `POST`   | Create dataset from CSV                  |
+    | `/catchAll/datasets`                            | `GET`    | List datasets                            |
+    | `/catchAll/datasets/{dataset_id}`               | `GET`    | Get dataset                              |
+    | `/catchAll/datasets/{dataset_id}`               | `PATCH`  | Update dataset name or description       |
+    | `/catchAll/datasets/{dataset_id}`               | `DELETE` | Delete dataset                           |
+    | `/catchAll/datasets/{dataset_id}/entities`      | `POST`   | Add entities to dataset                  |
+    | `/catchAll/datasets/{dataset_id}/entities`      | `DELETE` | Remove entities from dataset             |
+    | `/catchAll/datasets/{dataset_id}/entities`      | `GET`    | List entities in dataset                 |
+    | `/catchAll/datasets/{dataset_id}/status`        | `GET`    | Get dataset status history               |
+    | `/catchAll/datasets/{dataset_id}/upload`        | `POST`   | Add companies to dataset via CSV         |
   </Tab>
 
   <Tab title="Meta">

--- a/web-search-api/guides-and-concepts/company-search.mdx
+++ b/web-search-api/guides-and-concepts/company-search.mdx
@@ -4,78 +4,599 @@ sidebarTitle: Company search
 description: Track specific companies across CatchAll jobs with per-company relevance scores.
 ---
 
-Company search filters CatchAll job results to a predefined list of companies and
-scores each matching record per company. Use it when you want to track a specific
-set of companies — a portfolio, a competitor list, a watchlist — rather than run
-broad queries.
+Company search filters CatchAll job results to a predefined list of companies
+and scores each matching record per company. Use it when you want to track a
+specific set of companies — a portfolio, a competitor list, a watchlist — rather
+than run broad queries.
 
 ## How it works
 
 Company search uses three connected concepts:
 
 **Entities** are individual company definitions. Each entity stores identifying
-information — name, domain, alternative names, key persons — that the system uses
-to recognize the company in web content.
+information — name, domain, alternative names, key persons — that the system
+uses to recognize the company in web content.
 
 **Datasets** are named collections of entities. A dataset acts as a watchlist or
 portfolio. You create it once and can reuse it across multiple jobs and monitors.
 
-**Connected jobs** are standard CatchAll jobs submitted with a `connected_dataset_ids`
-parameter. Adding this parameter activates company search mode; everything else
-about the job — query, validators, enrichments, date ranges — works identically
-to a normal job.
+**Connected jobs** are standard CatchAll jobs submitted with a
+`connected_dataset_ids` parameter. Adding this parameter activates company
+search mode; everything else about the job — query, validators, enrichments,
+date ranges — works identically to a normal job.
 
-## Entities
+## Create entities
 
-An entity represents a company (or person) you want to track. Only `name` is
-required; all other fields are optional but improve matching quality.
+Matching quality depends on what you provide. `domain` is the most reliable
+signal — two companies can share a name, but not a domain.
 
-| Field | Required | Notes |
-|---|---|---|
-| `name` | Yes | Company name |
-| `entity_type` | No | `"company"` (default) or `"person"` |
-| `description` | No | Free-text description used for disambiguation |
-| `additional_attributes.company_attributes.domain` | No | Website domain — highest-signal field |
-| `additional_attributes.company_attributes.alternative_names` | No | Aliases and ticker symbols |
-| `additional_attributes.company_attributes.key_persons` | No | CEO, founders, and other key people |
+### Single entity
 
-Matching quality depends on what you provide. `domain` is the most reliable signal
-— two companies can share a name, but not a domain.
+<CodeGroup>
 
-### Status lifecycle
+```bash cURL
+curl -X POST "https://catchall.newscatcherapi.com/catchAll/entities" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "NewsCatcher",
+    "entity_type": "company",
+    "description": "AI-powered news data provider",
+    "additional_attributes": {
+      "company_attributes": {
+        "domain": "newscatcherapi.com",
+        "alternative_names": ["NC", "NewsCatcher API"],
+        "key_persons": ["Artem Bugara", "Maksym Sugonyaka"]
+      }
+    }
+  }'
+```
 
-Entities move through the following statuses after creation:
+```json JSON
+{
+  "name": "NewsCatcher",
+  "entity_type": "company",
+  "description": "AI-powered news data provider",
+  "additional_attributes": {
+    "company_attributes": {
+      "domain": "newscatcherapi.com",
+      "alternative_names": ["NC", "NewsCatcher API"],
+      "key_persons": ["Artem Bugara", "Maksym Sugonyaka"]
+    }
+  }
+}
+```
 
-`pending` → `enriching` → `ready` (or `failed`)
+```python Python
+from newscatcher_catchall import (
+    CatchAllApi,
+    AdditionalAttributes,
+    CompanyAttributes,
+)
+
+client = CatchAllApi(api_key="YOUR_API_KEY")
+
+entity = client.entities.create_entity(
+    name="NewsCatcher",
+    entity_type="company",
+    description="AI-powered news data provider",
+    additional_attributes=AdditionalAttributes(
+        company_attributes=CompanyAttributes(
+            domain="newscatcherapi.com",
+            alternative_names=["NC", "NewsCatcher API"],
+            key_persons=["Artem Bugara", "Maksym Sugonyaka"],
+        )
+    ),
+)
+entity_id = entity.id
+```
+
+```typescript TypeScript
+import { CatchAllApiClient } from "newscatcher-catchall-sdk";
+
+const client = new CatchAllApiClient({ apiKey: "YOUR_API_KEY" });
+
+const entity = await client.entities.createEntity({
+  name: "NewsCatcher",
+  entity_type: "company",
+  description: "AI-powered news data provider",
+  additional_attributes: {
+    company_attributes: {
+      domain: "newscatcherapi.com",
+      alternative_names: ["NC", "NewsCatcher API"],
+      key_persons: ["Artem Bugara", "Maksym Sugonyaka"],
+    },
+  },
+});
+const entityId = entity.id;
+```
+
+```java Java
+import com.newscatcher.catchall.CatchAllApi;
+import com.newscatcher.catchall.types.*;
+import java.util.List;
+
+CatchAllApi client = CatchAllApi.builder()
+    .apiKey("YOUR_API_KEY")
+    .build();
+
+CreateEntityResponse entity = client.entities().createEntity(
+    CreateEntityRequest.builder()
+        .name("NewsCatcher")
+        .entityType(EntityType.COMPANY)
+        .description("AI-powered news data provider")
+        .additionalAttributes(AdditionalAttributes.builder()
+            .companyAttributes(CompanyAttributes.builder()
+                .domain("newscatcherapi.com")
+                .alternativeNames(List.of("NC", "NewsCatcher API"))
+                .keyPersons(List.of("Artem Bugara", "Maksym Sugonyaka"))
+                .build())
+            .build())
+        .build()
+);
+String entityId = entity.getId();
+```
+
+</CodeGroup>
+
+<Expandable title="Create entity response">
+
+```json
+{
+  "id": "854198fa-f702-49db-a381-0427fa87f173",
+  "status": "pending"
+}
+```
+
+Entities move through `pending → enriching → ready` (or `failed`) after
+creation. You don't need to wait for individual entities to be ready before
+creating a dataset — the dataset status is what matters before submitting a job.
 
 <Note>
-  External enrichment is not yet active. Entities move directly to `ready` based
-  on the fields you supply. The behavior will change in a future release when the
-  enrichment pipeline is enabled.
+  External enrichment is not yet active. Entities move directly to `ready`
+  based on the fields you supply. This will change in a future release.
 </Note>
 
-## Datasets
+</Expandable>
 
-A dataset is a named, reusable collection of entities scoped to your organization.
-You can create a dataset from a CSV file — which creates entities and the dataset
-in a single step — or from a list of existing entity IDs via the JSON API. You
-can add entities to or remove them from a dataset at any time without affecting
-jobs that have already run.
+### Batch
 
-Datasets follow the same `pending → enriching → ready` (or `failed`) lifecycle
-as entities. A dataset must reach `ready` before it can be used in a job.
+Use batch creation when adding multiple entities at once. Each entity is
+processed independently — one failure does not affect the others.
+
+<CodeGroup>
+
+```bash cURL
+curl -X POST "https://catchall.newscatcherapi.com/catchAll/entities/batch" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "entities": [
+      {
+        "name": "NewsCatcher",
+        "entity_type": "company",
+        "additional_attributes": {
+          "company_attributes": { "domain": "newscatcherapi.com" }
+        }
+      },
+      {
+        "name": "OpenAI",
+        "entity_type": "company",
+        "additional_attributes": {
+          "company_attributes": {
+            "domain": "openai.com",
+            "key_persons": ["Sam Altman"]
+          }
+        }
+      }
+    ]
+  }'
+```
+
+```json JSON
+{
+  "entities": [
+    {
+      "name": "NewsCatcher",
+      "entity_type": "company",
+      "additional_attributes": {
+        "company_attributes": { "domain": "newscatcherapi.com" }
+      }
+    },
+    {
+      "name": "OpenAI",
+      "entity_type": "company",
+      "additional_attributes": {
+        "company_attributes": {
+          "domain": "openai.com",
+          "key_persons": ["Sam Altman"]
+        }
+      }
+    }
+  ]
+}
+```
+
+```python Python
+from newscatcher_catchall import (
+    CatchAllApi,
+    AdditionalAttributes,
+    CompanyAttributes,
+    CreateEntityRequest,
+)
+
+client = CatchAllApi(api_key="YOUR_API_KEY")
+
+result = client.entities.create_entities_batch(
+    entities=[
+        CreateEntityRequest(
+            name="NewsCatcher",
+            entity_type="company",
+            additional_attributes=AdditionalAttributes(
+                company_attributes=CompanyAttributes(
+                    domain="newscatcherapi.com",
+                )
+            ),
+        ),
+        CreateEntityRequest(
+            name="OpenAI",
+            entity_type="company",
+            additional_attributes=AdditionalAttributes(
+                company_attributes=CompanyAttributes(
+                    domain="openai.com",
+                    key_persons=["Sam Altman"],
+                )
+            ),
+        ),
+    ],
+)
+entity_ids = [e.id for e in result.entities]
+```
+
+```typescript TypeScript
+import { CatchAllApiClient } from "newscatcher-catchall-sdk";
+
+const client = new CatchAllApiClient({ apiKey: "YOUR_API_KEY" });
+
+const result = await client.entities.createEntitiesBatch({
+  entities: [
+    {
+      name: "NewsCatcher",
+      entity_type: "company",
+      additional_attributes: {
+        company_attributes: { domain: "newscatcherapi.com" },
+      },
+    },
+    {
+      name: "OpenAI",
+      entity_type: "company",
+      additional_attributes: {
+        company_attributes: {
+          domain: "openai.com",
+          key_persons: ["Sam Altman"],
+        },
+      },
+    },
+  ],
+});
+const entityIds = result.entities.map((e) => e.id);
+```
+
+```java Java
+import com.newscatcher.catchall.CatchAllApi;
+import com.newscatcher.catchall.resources.entities.requests.CreateEntitiesBatchRequest;
+import com.newscatcher.catchall.types.*;
+import java.util.List;
+
+CatchAllApi client = CatchAllApi.builder()
+    .apiKey("YOUR_API_KEY")
+    .build();
+
+CreateEntitiesBatchResponse result = client.entities().createEntitiesBatch(
+    CreateEntitiesBatchRequest.builder()
+        .entities(List.of(
+            CreateEntityRequest.builder()
+                .name("NewsCatcher")
+                .entityType(EntityType.COMPANY)
+                .additionalAttributes(AdditionalAttributes.builder()
+                    .companyAttributes(CompanyAttributes.builder()
+                        .domain("newscatcherapi.com")
+                        .build())
+                    .build())
+                .build(),
+            CreateEntityRequest.builder()
+                .name("OpenAI")
+                .entityType(EntityType.COMPANY)
+                .additionalAttributes(AdditionalAttributes.builder()
+                    .companyAttributes(CompanyAttributes.builder()
+                        .domain("openai.com")
+                        .keyPersons(List.of("Sam Altman"))
+                        .build())
+                    .build())
+                .build()
+        ))
+        .build()
+);
+```
+
+</CodeGroup>
+
+<Expandable title="Create entities batch response">
+
+```json
+{
+  "entities": [
+    {
+      "id": "854198fa-f702-49db-a381-0427fa87f173",
+      "status": "pending"
+    },
+    {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "status": "pending"
+    }
+  ],
+  "count": 2
+}
+```
+
+Results are returned in the same order as the input array.
+
+</Expandable>
+
+## Create a dataset
+
+### From entity IDs
+
+Create a dataset from existing entity IDs. All IDs must belong to your
+organization — any invalid ID returns `400`.
+
+<CodeGroup>
+
+```bash cURL
+curl -X POST "https://catchall.newscatcherapi.com/catchAll/datasets" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "My Portfolio",
+    "description": "Companies we track for partnership activity",
+    "entity_ids": [
+      "854198fa-f702-49db-a381-0427fa87f173",
+      "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    ]
+  }'
+```
+
+```json JSON
+{
+  "name": "My Portfolio",
+  "description": "Companies we track for partnership activity",
+  "entity_ids": [
+    "854198fa-f702-49db-a381-0427fa87f173",
+    "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+  ]
+}
+```
+
+```python Python
+dataset = client.datasets.create_dataset(
+    name="My Portfolio",
+    description="Companies we track for partnership activity",
+    entity_ids=entity_ids,
+)
+dataset_id = dataset.id
+```
+
+```typescript TypeScript
+const dataset = await client.datasets.createDataset({
+  name: "My Portfolio",
+  description: "Companies we track for partnership activity",
+  entity_ids: entityIds,
+});
+const datasetId = dataset.id;
+```
+
+```java Java
+import com.newscatcher.catchall.resources.datasets.requests.CreateDatasetRequest;
+import com.newscatcher.catchall.types.DatasetResponse;
+
+DatasetResponse dataset = client.datasets().createDataset(
+    CreateDatasetRequest.builder()
+        .name("My Portfolio")
+        .description("Companies we track for partnership activity")
+        .entityIds(entityIds)
+        .build()
+);
+String datasetId = dataset.getId();
+```
+
+</CodeGroup>
+
+<Expandable title="Create dataset response">
+
+```json
+{
+  "id": "ccabb755-afc2-4047-b84c-78d1f23d49b2",
+  "organization_id": "org_6f3a2b1c",
+  "name": "My Portfolio",
+  "description": "Companies we track for partnership activity",
+  "entity_count": 2,
+  "latest_status": "pending",
+  "created_at": "2026-04-10T09:00:00Z",
+  "updated_at": "2026-04-10T09:00:00Z"
+}
+```
+
+</Expandable>
+
+### From CSV
+
+Upload a CSV to create both entities and the dataset in a single request —
+the fastest path for most use cases.
+
+The `name` column is required; all other columns are optional. Use semicolons
+to separate multiple values in `alternative_names` and `key_persons`. Rows
+with an empty `name` are skipped and reported in `validation_report`.
+
+```csv
+name,description,domain,alternative_names,key_persons
+NewsCatcher,"AI-powered news data provider",newscatcherapi.com,"NC;NewsCatcher API","Artem Bugara;Maksym Sugonyaka"
+OpenAI,"Artificial intelligence research company",openai.com,"Open AI","Sam Altman"
+Stripe,"Online payments platform",stripe.com,"","Patrick Collison;John Collison"
+```
+
+<CodeGroup>
+
+```bash cURL
+curl -X POST "https://catchall.newscatcherapi.com/catchAll/datasets/upload" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -F "file=@companies.csv" \
+  -F "name=My Portfolio"
+```
+
+```python Python
+dataset = client.datasets.create_dataset_from_csv(
+    file=open("companies.csv", "rb"),
+    name="My Portfolio",
+)
+dataset_id = dataset.dataset_id
+```
+
+```typescript TypeScript
+import { createReadStream } from "fs";
+
+const dataset = await client.datasets.createDatasetFromCsv({
+  file: createReadStream("companies.csv"),
+  name: "My Portfolio",
+});
+const datasetId = dataset.dataset_id;
+```
+
+```java Java
+import com.newscatcher.catchall.resources.datasets.requests.CreateDatasetFromCsvRequest;
+import com.newscatcher.catchall.types.CreateDatasetCsvResponse;
+import java.io.File;
+
+CreateDatasetCsvResponse dataset = client.datasets().createDatasetFromCsv(
+    new File("companies.csv"),
+    CreateDatasetFromCsvRequest.builder()
+        .name("My Portfolio")
+        .build()
+);
+String datasetId = dataset.getDatasetId();
+```
+
+</CodeGroup>
+
+<Expandable title="Create dataset from CSV response">
+
+```json
+{
+  "dataset_id": "ccabb755-afc2-4047-b84c-78d1f23d49b2",
+  "dataset_name": "My Portfolio",
+  "entities_created": 3,
+  "validation_report": {
+    "total_rows": 3,
+    "valid_rows": 3,
+    "skipped_count": 0,
+    "skipped_rows": []
+  }
+}
+```
 
 <Note>
-  Only one dataset per job is currently supported, even though
+  The CSV response returns `dataset_id`, not `id`. This differs from the JSON
+  API path.
+</Note>
+
+</Expandable>
+
+## Wait for the dataset to be ready
+
+Poll [`GET /catchAll/datasets/{dataset_id}`](/web-search-api/api-reference/datasets/get-dataset)
+until `latest_status` reaches `ready`. Do not submit a job before this step
+completes.
+
+<CodeGroup>
+
+```bash cURL
+curl "https://catchall.newscatcherapi.com/catchAll/datasets/ccabb755-afc2-4047-b84c-78d1f23d49b2" \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+```python Python
+import time
+
+POLL_INTERVAL = 5  # seconds
+
+while True:
+    status = client.datasets.get_dataset(dataset_id)
+    if status.latest_status == "ready":
+        break
+    if status.latest_status == "failed":
+        raise RuntimeError("Dataset processing failed")
+    time.sleep(POLL_INTERVAL)
+```
+
+```typescript TypeScript
+const POLL_INTERVAL_MS = 5000;
+
+while (true) {
+  const status = await client.datasets.getDataset({ dataset_id: datasetId });
+  if (status.latest_status === "ready") break;
+  if (status.latest_status === "failed") {
+    throw new Error("Dataset processing failed");
+  }
+  await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+}
+```
+
+```java Java
+import com.newscatcher.catchall.types.DatasetResponse;
+import com.newscatcher.catchall.types.DatasetStatus;
+import java.util.concurrent.TimeUnit;
+
+while (true) {
+    DatasetResponse status = client.datasets().getDataset(datasetId);
+    if (DatasetStatus.READY.equals(status.getLatestStatus().orElse(null))) break;
+    if (DatasetStatus.FAILED.equals(status.getLatestStatus().orElse(null))) {
+        throw new RuntimeException("Dataset processing failed");
+    }
+    TimeUnit.SECONDS.sleep(5);
+}
+```
+
+</CodeGroup>
+
+<Expandable title="Get dataset response">
+
+```json
+{
+  "id": "ccabb755-afc2-4047-b84c-78d1f23d49b2",
+  "organization_id": "org_6f3a2b1c",
+  "name": "My Portfolio",
+  "description": "Companies we track for partnership activity",
+  "entity_count": 2,
+  "latest_status": "ready",
+  "created_at": "2026-04-10T09:00:00Z",
+  "updated_at": "2026-04-10T09:00:05Z"
+}
+```
+
+</Expandable>
+
+## Submit a connected job
+
+Add `connected_dataset_ids` to a standard job submission to activate company
+search mode:
+
+<Note>
+  Only one dataset per job is supported at this time, even though
   `connected_dataset_ids` accepts an array.
 </Note>
 
-## Company search jobs
+<CodeGroup>
 
-To activate company search, add `connected_dataset_ids` to a standard job
-submission:
-
-```bash
+```bash cURL
 curl -X POST "https://catchall.newscatcherapi.com/catchAll/submit" \
   -H "x-api-key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
@@ -85,51 +606,153 @@ curl -X POST "https://catchall.newscatcherapi.com/catchAll/submit" \
   }'
 ```
 
-The job processes identically to a normal job — only the results differ.
+```json JSON
+{
+  "query": "AI chip partnerships",
+  "connected_dataset_ids": ["ccabb755-afc2-4047-b84c-78d1f23d49b2"]
+}
+```
 
-## Output
+```python Python
+job = client.jobs.create_job(
+    query="AI chip partnerships",
+    connected_dataset_ids=[dataset_id],
+)
+job_id = job.job_id
+```
 
-Each matching record includes a `connected_entities` array with one entry per
-matched entity.
+```typescript TypeScript
+const job = await client.jobs.createJob({
+  query: "AI chip partnerships",
+  connected_dataset_ids: [datasetId],
+});
+const jobId = job.job_id;
+```
 
-| Field | Type | Notes |
-|---|---|---|
-| `entity_id` | string | UUID of the matched entity |
-| `name` | string | Entity name |
-| `ed_score` | number | Relevance score from 1 to 10. Entities scoring 0 are filtered from output and never appear. |
-| `relation` | string | Description of how the entity relates to the record. Maximum 100 characters. |
+```java Java
+import com.newscatcher.catchall.resources.jobs.requests.SubmitRequestDto;
+import java.util.List;
 
-Example record with `connected_entities`:
+var job = client.jobs().createJob(
+    SubmitRequestDto.builder()
+        .query("AI chip partnerships")
+        .connectedDatasetIds(List.of(datasetId))
+        .build()
+);
+String jobId = job.getJobId();
+```
+
+</CodeGroup>
+
+Poll [`GET /catchAll/status/{job_id}`](/web-search-api/api-reference/jobs/get-job-status)
+until `status` is `completed`, then retrieve results. See
+[Jobs](/web-search-api/guides-and-concepts/jobs) for the polling pattern.
+
+## Get results
+
+Retrieve results the same way as a normal job. Each record includes a
+`connected_entities` array with one entry per matched company. Entities with
+`ed_score` of 0 are filtered out automatically and never appear.
+
+<CodeGroup>
+
+```bash cURL
+curl "https://catchall.newscatcherapi.com/catchAll/pull/{job_id}" \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+```python Python
+results = client.jobs.get_job_results(job_id)
+
+for record in results.all_records:
+    print(record.record_title)
+    for entity in record.connected_entities:
+        print(f"  {entity.name} — score {entity.ed_score}/10")
+        print(f"  {entity.relation}")
+```
+
+```typescript TypeScript
+const results = await client.jobs.getJobResults({ job_id: jobId });
+
+for (const record of results.all_records) {
+  console.log(record.record_title);
+  for (const entity of record.connected_entities ?? []) {
+    console.log(`  ${entity.name} — score ${entity.ed_score}/10`);
+    console.log(`  ${entity.relation}`);
+  }
+}
+```
+
+```java Java
+import com.newscatcher.catchall.types.PullJobResponseDto;
+
+PullJobResponseDto results = client.jobs().getJobResults(jobId);
+
+results.getAllRecords().forEach(record -> {
+    System.out.println(record.getRecordTitle());
+    record.getConnectedEntities().ifPresent(entities ->
+        entities.forEach(entity -> {
+            System.out.printf("  %s — score %.0f/10%n",
+                entity.getName(), entity.getEdScore());
+            System.out.println("  " + entity.getRelation());
+        })
+    );
+});
+```
+
+</CodeGroup>
+
+<Expandable title="Get results response">
 
 ```json
 {
-  "record_id": "6417909601438475967",
-  "record_title": "NVIDIA Expands AI Infrastructure Partnership with NewsCatcher",
-  "enrichment": {
-    "partnership_type": "technology integration",
-    "deal_stage": "announced",
-    "enrichment_confidence": "high"
-  },
-  "citations": [
+  "job_id": "5f0c9087-85cb-4917-b3c7-e5a5eff73a0c",
+  "query": "AI chip partnerships",
+  "status": "completed",
+  "valid_records": 1,
+  "all_records": [
     {
-      "title": "NVIDIA Announces New AI Data Partners",
-      "link": "https://example.com/nvidia-ai-partners",
-      "published_date": "2026-04-10T09:00:00Z"
-    }
-  ],
-  "connected_entities": [
-    {
-      "entity_id": "854198fa-f702-49db-a381-0427fa87f173",
-      "name": "NewsCatcher",
-      "ed_score": 9,
-      "relation": "NewsCatcher is a named partner in the announced AI infrastructure deal"
+      "record_id": "6417909601438475967",
+      "record_title": "NVIDIA Expands AI Infrastructure Partnership with NewsCatcher",
+      "enrichment": {
+        "partnership_type": "technology integration",
+        "deal_stage": "announced",
+        "enrichment_confidence": "high"
+      },
+      "citations": [
+        {
+          "title": "NVIDIA Announces New AI Data Partners",
+          "link": "https://example.com/nvidia-ai-partners",
+          "published_date": "2026-04-10T09:00:00Z"
+        }
+      ],
+      "connected_entities": [
+        {
+          "entity_id": "854198fa-f702-49db-a381-0427fa87f173",
+          "name": "NewsCatcher",
+          "ed_score": 9,
+          "relation": "NewsCatcher is a named partner in the announced AI infrastructure deal"
+        }
+      ]
     }
   ]
 }
 ```
 
-<Tip>
-  For step-by-step instructions including entity creation, CSV upload, dataset
-  polling, and reading results in Python, TypeScript, and Java, see
-  [Set up company search](/web-search-api/how-to/set-up-company-search).
-</Tip>
+**`connected_entities` fields:**
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `entity_id` | string | UUID of the matched entity |
+| `name` | string | Entity name |
+| `ed_score` | number | Relevance score from 1 to 10 |
+| `relation` | string | How the entity relates to the record. Maximum 100 characters. |
+
+</Expandable>
+
+## See also
+
+- [Jobs](/web-search-api/guides-and-concepts/jobs)
+- [Monitors](/web-search-api/guides-and-concepts/monitors)
+- [Entities API reference](/web-search-api/api-reference/entities/create-entity)
+- [Datasets API reference](/web-search-api/api-reference/datasets/create-dataset)

--- a/web-search-api/guides-and-concepts/company-search.mdx
+++ b/web-search-api/guides-and-concepts/company-search.mdx
@@ -1,0 +1,135 @@
+---
+title: Company search
+sidebarTitle: Company search
+description: Track specific companies across CatchAll jobs with per-company relevance scores.
+---
+
+Company search filters CatchAll job results to a predefined list of companies and
+scores each matching record per company. Use it when you want to track a specific
+set of companies — a portfolio, a competitor list, a watchlist — rather than run
+broad queries.
+
+## How it works
+
+Company search uses three connected concepts:
+
+**Entities** are individual company definitions. Each entity stores identifying
+information — name, domain, alternative names, key persons — that the system uses
+to recognize the company in web content.
+
+**Datasets** are named collections of entities. A dataset acts as a watchlist or
+portfolio. You create it once and can reuse it across multiple jobs and monitors.
+
+**Connected jobs** are standard CatchAll jobs submitted with a `connected_dataset_ids`
+parameter. Adding this parameter activates company search mode; everything else
+about the job — query, validators, enrichments, date ranges — works identically
+to a normal job.
+
+## Entities
+
+An entity represents a company (or person) you want to track. Only `name` is
+required; all other fields are optional but improve matching quality.
+
+| Field | Required | Notes |
+|---|---|---|
+| `name` | Yes | Company name |
+| `entity_type` | No | `"company"` (default) or `"person"` |
+| `description` | No | Free-text description used for disambiguation |
+| `additional_attributes.company_attributes.domain` | No | Website domain — highest-signal field |
+| `additional_attributes.company_attributes.alternative_names` | No | Aliases and ticker symbols |
+| `additional_attributes.company_attributes.key_persons` | No | CEO, founders, and other key people |
+
+Matching quality depends on what you provide. `domain` is the most reliable signal
+— two companies can share a name, but not a domain.
+
+### Status lifecycle
+
+Entities move through the following statuses after creation:
+
+`pending` → `enriching` → `ready` (or `failed`)
+
+<Note>
+  External enrichment is not yet active. Entities move directly to `ready` based
+  on the fields you supply. The behavior will change in a future release when the
+  enrichment pipeline is enabled.
+</Note>
+
+## Datasets
+
+A dataset is a named, reusable collection of entities scoped to your organization.
+You can create a dataset from a CSV file — which creates entities and the dataset
+in a single step — or from a list of existing entity IDs via the JSON API. You
+can add entities to or remove them from a dataset at any time without affecting
+jobs that have already run.
+
+Datasets follow the same `pending → enriching → ready` (or `failed`) lifecycle
+as entities. A dataset must reach `ready` before it can be used in a job.
+
+<Note>
+  Only one dataset per job is currently supported, even though
+  `connected_dataset_ids` accepts an array.
+</Note>
+
+## Company search jobs
+
+To activate company search, add `connected_dataset_ids` to a standard job
+submission:
+
+```bash
+curl -X POST "https://catchall.newscatcherapi.com/catchAll/submit" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "AI chip partnerships",
+    "connected_dataset_ids": ["ccabb755-afc2-4047-b84c-78d1f23d49b2"]
+  }'
+```
+
+The job processes identically to a normal job — only the results differ.
+
+## Output
+
+Each matching record includes a `connected_entities` array with one entry per
+matched entity.
+
+| Field | Type | Notes |
+|---|---|---|
+| `entity_id` | string | UUID of the matched entity |
+| `name` | string | Entity name |
+| `ed_score` | number | Relevance score from 1 to 10. Entities scoring 0 are filtered from output and never appear. |
+| `relation` | string | Description of how the entity relates to the record. Maximum 100 characters. |
+
+Example record with `connected_entities`:
+
+```json
+{
+  "record_id": "6417909601438475967",
+  "record_title": "NVIDIA Expands AI Infrastructure Partnership with NewsCatcher",
+  "enrichment": {
+    "partnership_type": "technology integration",
+    "deal_stage": "announced",
+    "enrichment_confidence": "high"
+  },
+  "citations": [
+    {
+      "title": "NVIDIA Announces New AI Data Partners",
+      "link": "https://example.com/nvidia-ai-partners",
+      "published_date": "2026-04-10T09:00:00Z"
+    }
+  ],
+  "connected_entities": [
+    {
+      "entity_id": "854198fa-f702-49db-a381-0427fa87f173",
+      "name": "NewsCatcher",
+      "ed_score": 9,
+      "relation": "NewsCatcher is a named partner in the announced AI infrastructure deal"
+    }
+  ]
+}
+```
+
+<Tip>
+  For step-by-step instructions including entity creation, CSV upload, dataset
+  polling, and reading results in Python, TypeScript, and Java, see
+  [Set up company search](/web-search-api/how-to/set-up-company-search).
+</Tip>

--- a/web-search-api/guides-and-concepts/jobs.mdx
+++ b/web-search-api/guides-and-concepts/jobs.mdx
@@ -151,6 +151,13 @@ If you omit both, the system generates both from scratch based on your query.
   job](#continue-job) to process more records without restarting.
 </Tip>
 
+<Note>
+  To activate Company search mode and filter results to specific companies,
+  add `connected_dataset_ids` to your submit request. See [Company
+  search](/web-search-api/guides-and-concepts/company-search) for setup
+  instructions.
+</Note>
+
 <CodeGroup>
 ```bash cURL
 curl -X POST "https://catchall.newscatcherapi.com/catchAll/submit" \
@@ -224,11 +231,6 @@ System.out.println("Job created: " + jobId);
 }
 ```
 </Expandable>
-
-<Note>
-  If you submit without a `limit`, the job processes all available data for the
-  scope, and there is nothing left for [Continue job](#continue-job).
-</Note>
 
 ## Get job status
 
@@ -527,6 +529,13 @@ while (true) {
   the example above) return a structured object with confidence scores for entity
   identification and domain resolution. See the [Company enrichment](/web-search-api/api-reference/jobs/company-enrichment-dto) data model.
 </Note>
+
+<Info>
+  Records from Company Search jobs include a `connected_entities` array with
+  one entry per matched company — each with `entity_id`, `name`, `ed_score`
+  (1–10), and `relation`. See [Company search](/web-search-api/guides-and-concepts/company-search) 
+  for the full output format.
+</Info>
 
 ## Continue job
 

--- a/web-search-api/libraries/java.mdx
+++ b/web-search-api/libraries/java.mdx
@@ -12,7 +12,7 @@ Java SDK provides access to the CatchAll API from Java applications.
   <Tab title="Gradle">
     ```groovy
     dependencies {
-        implementation 'com.newscatcherapi:newscatcher-catchall-sdk:0.3.1'
+        implementation 'com.newscatcherapi:newscatcher-catchall-sdk:1.4.0'
     }
     ```
   </Tab>
@@ -22,7 +22,7 @@ Java SDK provides access to the CatchAll API from Java applications.
     <dependency>
         <groupId>com.newscatcherapi</groupId>
         <artifactId>newscatcher-catchall-sdk</artifactId>
-        <version>0.3.1</version>
+        <version>1.4.0</version>
     </dependency>
     ```
   </Tab>
@@ -667,6 +667,125 @@ public class MonitorExample {
 }
 ```
 </Accordion>
+
+## Company search
+
+Company search lets you track specific companies across jobs. Create entities,
+group them into a dataset, then connect the dataset to any job to get per-company
+relevance scores in results.
+
+<Tabs>
+  <Tab title="Create entity">
+```java
+import com.newscatcher.catchall.CatchAllApi;
+import com.newscatcher.catchall.types.AdditionalAttributes;
+import com.newscatcher.catchall.types.CompanyAttributes;
+import com.newscatcher.catchall.types.CreateEntityRequest;
+import com.newscatcher.catchall.types.CreateEntityResponse;
+import com.newscatcher.catchall.types.EntityType;
+import java.util.List;
+
+CatchAllApi client = CatchAllApi.builder()
+    .apiKey("YOUR_API_KEY")
+    .build();
+
+CreateEntityResponse entity = client.entities().createEntity(
+    CreateEntityRequest.builder()
+        .name("NewsCatcher")
+        .entityType(EntityType.COMPANY)
+        .description("AI-powered news data provider")
+        .additionalAttributes(AdditionalAttributes.builder()
+            .companyAttributes(CompanyAttributes.builder()
+                .domain("newscatcherapi.com")
+                .alternativeNames(List.of("NC", "NewsCatcher API"))
+                .keyPersons(List.of("Artem Bugara", "Maksym Sugonyaka"))
+                .build())
+            .build())
+        .build()
+);
+String entityId = entity.getId();
+```
+  </Tab>
+
+  <Tab title="Create dataset from CSV">
+    Upload a CSV to create a dataset and entities in one step:
+
+```java
+import com.newscatcher.catchall.resources.datasets.requests.CreateDatasetFromCsvRequest;
+import com.newscatcher.catchall.types.CreateDatasetCsvResponse;
+import java.io.File;
+
+CreateDatasetCsvResponse dataset = client.datasets().createDatasetFromCsv(
+    new File("companies.csv"),
+    CreateDatasetFromCsvRequest.builder()
+        .name("My Portfolio")
+        .build()
+);
+String datasetId = dataset.getDatasetId();
+```
+
+    CSV format:
+
+```csv
+name,description,domain,alternative_names,key_persons
+NewsCatcher,"AI-powered news data provider",newscatcherapi.com,"NC;NewsCatcher API","Artem Bugara;Maksym Sugonyaka"
+OpenAI,"Artificial intelligence research company",openai.com,"Open AI","Sam Altman"
+```
+  </Tab>
+
+  <Tab title="Submit connected job">
+    Wait for the dataset to reach `ready` status, then submit a job:
+
+```java
+import com.newscatcher.catchall.types.DatasetResponse;
+import com.newscatcher.catchall.types.DatasetStatus;
+import com.newscatcher.catchall.resources.jobs.requests.SubmitRequestDto;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+// Poll until ready
+while (true) {
+    DatasetResponse status = client.datasets().getDataset(datasetId);
+    if (DatasetStatus.READY.equals(status.getLatestStatus().orElse(null))) break;
+    TimeUnit.SECONDS.sleep(5);
+}
+
+// Submit connected job
+var job = client.jobs().createJob(
+    SubmitRequestDto.builder()
+        .query("AI chip partnerships")
+        .connectedDatasetIds(List.of(datasetId))
+        .build()
+);
+```
+  </Tab>
+
+  <Tab title="Read results">
+    Each record includes a `connected_entities` list with relevance scores:
+
+```java
+import com.newscatcher.catchall.types.PullJobResponseDto;
+
+PullJobResponseDto results = client.jobs().getJobResults(job.getJobId());
+
+results.getAllRecords().forEach(record -> {
+    System.out.println(record.getRecordTitle());
+    record.getConnectedEntities().ifPresent(entities ->
+        entities.forEach(entity -> {
+            System.out.printf("  %s: score %.0f/10%n",
+                entity.getName(), entity.getEdScore());
+            System.out.println("  " + entity.getRelation());
+        })
+    );
+});
+```
+  </Tab>
+</Tabs>
+
+<Tip>
+  For a full step-by-step walkthrough including batch entity creation and the
+  JSON API path, see [Set up company search](/web-search-api/how-to/set-up-company-search).
+</Tip>
 
 ## Error handling
 

--- a/web-search-api/libraries/python.mdx
+++ b/web-search-api/libraries/python.mdx
@@ -514,6 +514,100 @@ except ApiError as e:
 ```
 </Accordion>
 
+## Company search
+
+Company search lets you track specific companies across jobs. Create entities,
+group them into a dataset, then connect the dataset to any job to get per-company
+relevance scores in results.
+
+<Tabs>
+  <Tab title="Create entity">
+```python
+from newscatcher_catchall import (
+    CatchAllApi,
+    AdditionalAttributes,
+    CompanyAttributes,
+)
+
+client = CatchAllApi(api_key="YOUR_API_KEY")
+
+entity = client.entities.create_entity(
+    name="NewsCatcher",
+    entity_type="company",
+    description="AI-powered news data provider",
+    additional_attributes=AdditionalAttributes(
+        company_attributes=CompanyAttributes(
+            domain="newscatcherapi.com",
+            alternative_names=["NC", "NewsCatcher API"],
+            key_persons=["Artem Bugara", "Maksym Sugonyaka"],
+        )
+    ),
+)
+entity_id = entity.id
+```
+  </Tab>
+
+  <Tab title="Create dataset from CSV">
+    Upload a CSV to create a dataset and entities in one step:
+
+```python
+dataset = client.datasets.create_dataset_from_csv(
+    file=open("companies.csv", "rb"),
+    name="My Portfolio",
+)
+dataset_id = dataset.dataset_id
+```
+
+    CSV format:
+
+```csv
+name,description,domain,alternative_names,key_persons
+NewsCatcher,"AI-powered news data provider",newscatcherapi.com,"NC;NewsCatcher API","Artem Bugara;Maksym Sugonyaka"
+OpenAI,"Artificial intelligence research company",openai.com,"Open AI","Sam Altman"
+```
+  </Tab>
+
+  <Tab title="Submit connected job">
+    Wait for the dataset to reach `ready` status, then submit a job:
+
+```python
+import time
+
+# Poll until ready
+while True:
+    status = client.datasets.get_dataset(dataset_id)
+    if status.latest_status == "ready":
+        break
+    time.sleep(5)
+
+# Submit connected job
+job = client.jobs.create_job(
+    query="AI chip partnerships",
+    connected_dataset_ids=[dataset_id],
+)
+```
+  </Tab>
+
+  <Tab title="Read results">
+    Each record includes a `connected_entities` array with relevance scores:
+
+```python
+results = client.jobs.get_job_results(job.job_id)
+
+for record in results.all_records:
+    print(record.record_title)
+    for entity in record.connected_entities:
+        print(f"  {entity.name}: score {entity.ed_score}/10")
+        print(f"  {entity.relation}")
+```
+  </Tab>
+</Tabs>
+
+<Tip>
+  For a full step-by-step walkthrough including batch entity creation and the
+  JSON API path, see [Set up company search](/web-search-api/how-to/set-up-company-search).
+</Tip>
+
 ## Async usage
 
 Use the async client for non-blocking API calls:

--- a/web-search-api/libraries/typescript.mdx
+++ b/web-search-api/libraries/typescript.mdx
@@ -542,6 +542,100 @@ try {
 ```
 </Accordion>
 
+## Company search
+
+Company search lets you track specific companies across jobs. Create entities,
+group them into a dataset, then connect the dataset to any job to get per-company
+relevance scores in results.
+
+<Tabs>
+  <Tab title="Create entity">
+```typescript
+import { CatchAllApiClient } from "newscatcher-catchall-sdk";
+
+const client = new CatchAllApiClient({ apiKey: "YOUR_API_KEY" });
+
+const entity = await client.entities.createEntity({
+  name: "NewsCatcher",
+  entity_type: "company",
+  description: "AI-powered news data provider",
+  additional_attributes: {
+    company_attributes: {
+      domain: "newscatcherapi.com",
+      alternative_names: ["NC", "NewsCatcher API"],
+      key_persons: ["Artem Bugara", "Maksym Sugonyaka"],
+    },
+  },
+});
+const entityId = entity.id;
+```
+  </Tab>
+
+  <Tab title="Create dataset from CSV">
+    Upload a CSV to create a dataset and entities in one step:
+
+```typescript
+import { createReadStream } from "fs";
+
+const dataset = await client.datasets.createDatasetFromCsv({
+  file: createReadStream("companies.csv"),
+  name: "My Portfolio",
+});
+const datasetId = dataset.dataset_id;
+```
+
+    CSV format:
+
+```csv
+name,description,domain,alternative_names,key_persons
+NewsCatcher,"AI-powered news data provider",newscatcherapi.com,"NC;NewsCatcher API","Artem Bugara;Maksym Sugonyaka"
+OpenAI,"Artificial intelligence research company",openai.com,"Open AI","Sam Altman"
+```
+  </Tab>
+
+  <Tab title="Submit connected job">
+    Wait for the dataset to reach `ready` status, then submit a job:
+
+```typescript
+const POLL_INTERVAL_MS = 5000;
+
+// Poll until ready
+while (true) {
+  const status = await client.datasets.getDataset({ dataset_id: datasetId });
+  if (status.latest_status === "ready") break;
+  await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+}
+
+// Submit connected job
+const job = await client.jobs.createJob({
+  query: "AI chip partnerships",
+  connected_dataset_ids: [datasetId],
+});
+```
+  </Tab>
+
+  <Tab title="Read results">
+    Each record includes a `connected_entities` array with relevance scores:
+
+```typescript
+const results = await client.jobs.getJobResults({ job_id: job.job_id });
+
+for (const record of results.all_records) {
+  console.log(record.record_title);
+  for (const entity of record.connected_entities ?? []) {
+    console.log(`  ${entity.name}: score ${entity.ed_score}/10`);
+    console.log(`  ${entity.relation}`);
+  }
+}
+```
+  </Tab>
+</Tabs>
+
+<Tip>
+  For a full step-by-step walkthrough including batch entity creation and the
+  JSON API path, see [Set up company search](/web-search-api/how-to/set-up-company-search).
+</Tip>
+
 ## Type safety
 
 The SDK exports all request and response types for full TypeScript support:


### PR DESCRIPTION
## What

Adds complete documentation for the company search feature introduced in CatchAll API v1.4.0. Covers the full surface area: OAS, API reference pages, a new guide, and SDK library doc updates for Python, TypeScript, and Java.

## Why

API v1.4.0 ships entities and datasets endpoints along with connected job support. All three SDKs have been regenerated and published. This PR brings the public docs up to date before users start hitting the new endpoints.

## Changes

**OAS and API reference**
- Update OAS to v1.4.0 — add entity/dataset schemas, `connected_dataset_ids` to `SubmitRequestDto`, `connected_entities` to `Record`, normalize acronyms (`CSV → Csv`, `DTO → Dto`)
- Add 6 entity endpoint pages (`create-entity`, `create-entities-batch`, `list-entities`, `get-entity`, `update-entity`, `delete-entity`)
- Add 11 dataset endpoint pages (`create-dataset`, `create-dataset-from-csv`, `list-datasets`, `get-dataset`, `update-dataset`, `delete-dataset`, `list-entities-in-dataset`, `add-entities-to-dataset`, `remove-entities-from-dataset`, `get-dataset-status-history`, `upload-csv-to-dataset`)

**Navigation**
- Add Entities and Datasets groups to API reference navigation in `docs.json`
- Add `company-search` to guides-and-concepts navigation

**Existing docs**
- `introduction.mdx` — add Company search accordion, Entities and Datasets endpoint tabs
- `changelog.mdx` — add v1.4.0 entry with full endpoint list
- `jobs.mdx` — document `connected_dataset_ids` on submit and `connected_entities` on results

**New guide**
- Add `guides-and-concepts/company-search.mdx` — single rich guide covering the full workflow: create entities (single and batch), create a dataset (JSON API and CSV paths), poll until ready, submit a connected job, read results; includes cURL, Python, TypeScript, and Java code examples with expandable response examples

**SDK library docs**
- Add Company search section to `libraries/python.mdx`, `libraries/typescript.mdx`, `libraries/java.mdx` — four-tab pattern (create entity, create dataset from CSV, submit connected job, read results), links to the guide

**Sitemap and llms.txt**
- Regenerate to include new pages

## Testing

- [x] Manually verified: all new API reference pages render correctly against the updated OAS
- [x] Manually verified: navigation groups appear in correct order (Entities → Datasets → Meta)
- [x] Manually verified: code examples in `company-search.mdx` match confirmed SDK method signatures from published v1.4.0 packages
- [x] Manually verified: `company-search` appears correctly in guides-and-concepts sidebar

## Notes

This is a large PR by necessity — the feature touches every documentation layer simultaneously (OAS → API ref → guide → SDK docs). Changes are additive; no existing content was removed.

One deliberate scope decision: the original plan was to separate the how-to page, but it was later consolidated into the main guide to match the pattern established by `jobs.mdx` and `monitors.mdx`, which combine conceptual explanation and practical code in a single document.

SDK release notes (GitHub releases on the three SDK repos) are handled separately and not part of this PR.

Suggested review order: `catch-all-api.yml` → `api-reference/entities/*` → `api-reference/datasets/*` → `docs.json` → `guides-and-concepts/company-search.mdx` → `libraries/*.mdx` → `get-started/*.mdx`