### PR TITLE
docs(news-api): clarify NLP data availability for pre-July 2023 data

### DIFF
--- a/news-api/api-reference/news-api-v3.yml
+++ b/news-api/api-reference/news-api-v3.yml
@@ -3469,6 +3469,8 @@ components:
       description: |
         If true, includes an NLP object for each article in the response. This object provides results of NLP analysis, including article theme, summary, sentiment, tags, and named entity recognition if available.
 
+        **Note**: NLP data is only available for articles indexed from July 2023 onward. For articles indexed before July 2023, the `nlp` field is returned as an empty object `{}`.
+
         To learn more, see [NLP features](https://www.newscatcherapi.com/docs/news-api/guides-and-concepts/nlp-features).
       example: true
 
@@ -3477,6 +3479,8 @@ components:
       default: false
       description: |
         If true, filters results to include only articles that have NLP data.
+
+        **Note**: NLP data is only available for articles indexed from July 2023 onward. Applying this filter to a date range that predates July 2023 returns zero results.
 
         To learn more, see [NLP features](https://www.newscatcherapi.com/docs/news-api/guides-and-concepts/nlp-features).
       example: true

--- a/news-api/get-started/subscription-plans.mdx
+++ b/news-api/get-started/subscription-plans.mdx
@@ -38,8 +38,16 @@ and English translations.
 - Enable article clustering with customizable thresholds
 - Use content deduplication
 - Access English translations of non-English content
-- **Full NLP processing on translations:** All NLP features (sentiment,
+- Full NLP processing on translations: All NLP features (sentiment,
   entities, summaries) work on English translations of foreign content
+
+<Note>
+  **NLP features apply to articles indexed from July 2023 onward**. Historical
+  articles from 2019 to June 2023 include core metadata only. NLP enrichment
+  for that period is available upon request — contact
+  [support@newscatcherapi.com](mailto:support@newscatcherapi.com) to discuss
+  your needs.
+</Note>
 
  </Tab>
  <Tab title="IPTC Tags" icon="tags">

--- a/news-api/guides-and-concepts/nlp-features.mdx
+++ b/news-api/guides-and-concepts/nlp-features.mdx
@@ -9,13 +9,22 @@ News API, how to use them, and their practical applications. By leveraging
 these NLP capabilities, you can extract meaningful insights from news data,
 enhancing your analysis, research, and application development.
 
+<Warning>
+  **NLP data is available only for articles indexed from July 2023 onward.** 
+  For articles collected before July 2023, the `nlp` field is present in the 
+  response but returned as an empty object `{}`. 
+  
+  To request NLP enrichment for pre-July 2023 historical data, contact 
+  [support@newscatcherapi.com](mailto:support@newscatcherapi.com).
+</Warning>
+
 ## Understanding NLP layer
 
 When processing news, we summarize the article content, categorize articles by
 theme, estimate the overall tone of the writing, and identify important names
 and places mentioned in the text. As a result, we supply each processed article
 with additional NLP information that you can use when making requests via News
-API v3.
+API.
 
 The NLP layer in News API consists of the following components:
 
@@ -69,7 +78,20 @@ data:
 
 #### NLP coverage by language
 
-All articles receive NLP processing through one of two methods:
+All articles undergo NLP processing using one of two methods: native 
+(NLP is performed on the original content) or translation-based 
+(NLP is performed on English translations). 
+
+For English and Arabic articles, we perform native NLP processing on the original text. 
+
+For all other languages, we perform translation-based NLP processing: articles 
+are automatically translated into English, and NLP is then applied to the 
+translation. Results are available in NLP translation fields such as 
+`nlp.translation_ner_PER` and `nlp.summary_translated`.
+
+To learn how to access and search translation-based NLP data, see 
+[Search in translations](/news-api/how-to/search-in-translations).
+
 
 | Feature                          | Native (Original Content)          | Translation-Based (All Languages)     | Notes                                                |
 | -------------------------------- | ---------------------------------- | ------------------------------------- | ---------------------------------------------------- |
@@ -82,11 +104,7 @@ All articles receive NLP processing through one of two methods:
 | Clustering                       | All languages                      | N/A                                   | Available for all content                            |
 | Deduplication                    | All languages                      | N/A                                   | Available for all content                            |
 
-<Note>
-  **How it works**: Non-English/Arabic articles are automatically translated to English, then NLP processing is performed on the translation. Results are available in `translation_*` fields (e.g., `nlp.translation_ner_PER`, `nlp.summary_translated`). To learn how to access and search translation-based NLP data, see [Search in translations](/news-api/how-to/search-in-translations).
-</Note>
-
-For a complete list of supported languages, see
+For a complete list of supported languages, review the 
 [language codes in News API](/news-api/api-reference/enumerated-parameters#language-lang-and-not-lang).
 
 ### Code example

--- a/news-api/guides-and-concepts/working-with-historical-data.mdx
+++ b/news-api/guides-and-concepts/working-with-historical-data.mdx
@@ -24,6 +24,15 @@ Key implications of this structure:
 - Queries across very long time periods (e.g., 5+ years) can cause performance
   issues.
 
+<Warning>
+  **NLP data is available only for articles indexed from July 2023 onward.** 
+  For articles collected before July 2023, the `nlp` field is present in the 
+  response but returned as an empty object `{}`. 
+  
+  To request NLP enrichment for pre-July 2023 historical data, contact 
+  [support@newscatcherapi.com](mailto:support@newscatcherapi.com).
+</Warning>
+
 ## Technical limitations
 
 While you technically can query data across our entire historical range (2019 to
@@ -695,14 +704,15 @@ if (require.main === module) {
 
 ## Common pitfalls to avoid
 
-| Pitfall                              | Impact                                  | Solution                                                                        |
-| ------------------------------------ | --------------------------------------- | ------------------------------------------------------------------------------- |
-| Querying multiple years at once      | Slow performance, timeouts (408 errors) | Break queries into monthly chunks                                               |
-| Using overly broad search terms      | Excessive result volume                 | Refine query terms to be more specific                                          |
-| Insufficient error handling          | Failed data retrieval                   | Implement robust retry and error handling                                       |
-| Underestimating data volume          | Resource constraints                    | Use aggregation endpoint to estimate volume first                               |
-| Requesting too many results per page | Slow response times                     | Use reasonable page sizes (100-1000)                                            |
-| Improper pagination implementation   | Incomplete data retrieval               | Follow our [pagination guide](/news-api/how-to/paginate-large-datasets) |
+| Pitfall                              | Impact                                     | Solution                                                                        |
+| ------------------------------------ | ------------------------------------------ | ------------------------------------------------------------------------------- |
+| Querying multiple years at once      | Slow performance, timeouts (408 errors)    | Break queries into monthly chunks                                               |
+| Using overly broad search terms      | Excessive result volume                    | Refine query terms to be more specific                                          |
+| Insufficient error handling          | Failed data retrieval                      | Implement robust retry and error handling                                       |
+| Underestimating data volume          | Resource constraints                       | Use aggregation endpoint to estimate volume first                               |
+| Requesting too many results per page | Slow response times                        | Use reasonable page sizes (100-1000)                                            |
+| Improper pagination implementation   | Incomplete data retrieval                  | Follow our [pagination guide](/news-api/how-to/paginate-large-datasets)         |
+| Expecting NLP data before July 2023  | `nlp` field is present but returned as `{}`| Set `has_nlp=true` to filter for NLP-enriched articles only                     |
 
 ## Related resources
 


### PR DESCRIPTION
## What

Add warnings and notes across four documents to clarify that NLP data is only available for articles indexed from July 2023 onward. For earlier articles, the API returns `"nlp": {}` — an empty object — even when `include_nlp_data=true` is set.

## Why

This behavior was documented only in the migration guide, which most users never read. Developers querying historical data had no warning that NLP fields would be empty, leading to silent failures in downstream processing.

Behavior verified via API call against a June 2022 date range with `include_nlp_data=true`.

## Changes

- Add `<Warning>` callout to `nlp-features.mdx` before the component table
- Add `<Warning>` to `working-with-historical-data.mdx` indexing section and a new row to the pitfalls table
- Add `<Note>` to `subscription-plans.mdx` NLP plan tab
- Update the `IncludeNlpData` and `HasNlp` schema descriptions in the OAS `news-api-v3.yml` to reflect the exact response behavior - these changes apply to all API reference pages that include these parameters.

## Testing

- [x] Manually verified: `nlp: {}` returned for pre-July 2023 articles with `include_nlp_data=true`
- [x] Rendered locally in Mintlify dev server