### PR TITLE
docs(oas)!: update API reference to v1.5.3

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -34,11 +34,9 @@
 - [Get Job Results](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/get-job-results): Retrieve the final results for a completed job.
 - [Continue Job](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/continue-job): Continue an existing job to process more records beyond the initial limit.
 - [List User Jobs](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/list-user-jobs): Returns all jobs created by the authenticated user.
-- [Delete Job](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/delete-job): Soft-deletes a job. The job is flagged as deleted and no longer
-appears in list results. The underlying data is retained.
+- [Delete Job](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/delete-job): Soft-deletes a job. The job is flagged as deleted and no longer appears in list results. The underlying data is retained.
 
-Only the job owner can delete a job. Returns `404` if the job is not
-found or does not belong to the authenticated user.
+Only the job owner can delete a job. Returns `404` if the job is not found or does not belong to the authenticated user.
 
 Deleting an already-deleted job returns `200`.
 
@@ -68,9 +66,7 @@ Deleting an already-deleted monitor returns `200`.
 
 ### API Reference — Entities
 
-- [List Entities](https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/list-entities): Returns a paginated list of entities belonging to the authenticated
-organization. Supports filtering by status and entity type, and
-sorting by name, status, or creation date.
+- [List Entities](https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/list-entities): Returns a paginated list of entities belonging to the authenticated organization. Supports filtering by status and entity type, and sorting by name, status, or creation date.
 
 - [Create Entity](https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/create-entity): Creates a new company entity and begins background enrichment.
 
@@ -79,11 +75,9 @@ enrichment completes. Provide as much identifying information as
 possible — `domain` is the highest-signal field because it is
 unambiguous.
 
-- [Create Entities Batch](https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/create-entities-batch): Creates multiple entities in a single request. Each entity is
-processed independently — a failure in one does not affect others.
+- [Create Entities Batch](https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/create-entities-batch): Creates multiple entities in a single request. Each entity is processed independently — a failure in one does not affect others.
 
-Returns an array of `{id, status}` objects in the same order as
-the input array.
+Returns an array of `{id, status}` objects in the same order as the input array.
 
 - [Get Entity](https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/get-entity): Returns a single entity by ID with all attributes and current status.
 - [Update Entity](https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/update-entity): Updates one or more fields of an existing entity.
@@ -94,9 +88,7 @@ datasets and the search index. This operation cannot be undone.
 
 ### API Reference — Datasets
 
-- [List Datasets](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/list-datasets): Returns a paginated list of datasets belonging to the authenticated
-organization. Supports filtering by status and sorting by name,
-status, or creation date.
+- [List Datasets](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/list-datasets): Returns a paginated list of datasets belonging to the authenticated organization. Supports filtering by status and sorting by name, status, or creation date.
 
 - [Create Dataset](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/create-dataset): Creates a new dataset from a list of existing entity IDs.
 
@@ -107,9 +99,7 @@ be valid before the dataset is created.
 To create a dataset and entities in one step, use the [`Create dataset from CSV`](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/create-dataset-from-csv)
 endpoint instead.
 
-- [Create Dataset From Csv](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/create-dataset-from-csv): Creates a new dataset by uploading a CSV file. Each row in the CSV
-becomes an entity. The `name` column is required; all other columns
-are optional.
+- [Create Dataset From Csv](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/create-dataset-from-csv): Creates a new dataset by uploading a CSV file. Each row in the CSV becomes an entity. The `name` and `domain`columns are required; all other columns are optional.
 
 **CSV format:**
 ```csv
@@ -129,22 +119,17 @@ Use semicolons (`;`) to separate multiple values in `alternative_names` and `key
 not deleted — only the dataset itself. This operation cannot be
 undone.
 
-- [List Entities In Dataset](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/list-entities-in-dataset): Returns a paginated list of entities in a dataset. Supports filtering by status and entity type.
+- [List Entities In Dataset](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/list-entities-in-dataset): Returns a paginated list of entities in a dataset. Supports filtering by status, entity type, and name search.
 
 - [Add Entities To Dataset](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/add-entities-to-dataset): Adds one or more existing entities to a dataset. Returns the number of entities added.
 
-- [Remove Entities From Dataset](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/remove-entities-from-dataset): Removes one or more entities from a dataset. The entities themselves
-are not deleted — they are only removed from this dataset. Returns
-the number of entities removed.
+- [Remove Entities From Dataset](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/remove-entities-from-dataset): Removes one or more entities from a dataset. The entities themselves are not deleted — they are only removed from this dataset. Returns the number of entities removed.
 
-- [Get Dataset Status History](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/get-dataset-status-history): Returns the full status change history for a dataset, ordered
-chronologically from oldest to newest.
+- [Get Dataset Status History](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/get-dataset-status-history): Returns the full status change history for a dataset, ordered chronologically from oldest to newest.
 
-- [Upload Csv To Dataset](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/upload-csv-to-dataset): Appends new companies to an existing dataset by uploading a CSV file.
-Uses the same CSV format as the dataset creation endpoint.
+- [Upload Csv To Dataset](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/upload-csv-to-dataset): Appends new companies to an existing dataset by uploading a CSV file. Uses the same CSV format as the dataset creation endpoint.
 
-The response omits `dataset_name` compared to the create-from-CSV
-endpoint since the dataset already exists.
+The response omits `dataset_name` compared to the create-from-CSV endpoint since the dataset already exists.
 
 
 ### API Reference — Meta

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NewsCatcher CatchAll API
-  version: 1.5.0
+  version: 1.5.3
   description: |
     CatchAll is a web search API that generates unique datasets that don't exist anywhere else on the web. Built on NewsCatcher's proprietary real-world event index, it delivers state-of-the-art recall—finding all relevant events, not just top results.
 
@@ -219,8 +219,7 @@ paths:
         - Jobs
       summary: Continue job
       description:
-        Continue an existing job to process more records beyond the initial
-        limit.
+        Continue an existing job to process more records beyond the initial limit.
       operationId: continueJob
       externalDocs:
         description: Learn about job continuation and limits
@@ -250,11 +249,9 @@ paths:
         - Jobs
       summary: Delete job
       description: |
-        Soft-deletes a job. The job is flagged as deleted and no longer
-        appears in list results. The underlying data is retained.
+        Soft-deletes a job. The job is flagged as deleted and no longer appears in list results. The underlying data is retained.
 
-        Only the job owner can delete a job. Returns `404` if the job is not
-        found or does not belong to the authenticated user.
+        Only the job owner can delete a job. Returns `404` if the job is not found or does not belong to the authenticated user.
 
         Deleting an already-deleted job returns `200`.
       operationId: deleteJob
@@ -305,7 +302,8 @@ paths:
               $ref: "#/components/schemas/CreateMonitorRequestDto"
             example:
               reference_job_id: "5f0c9087-85cb-4917-b3c7-e5a5eff73a0c"
-              schedule: "every day at 12 PM UTC"
+              schedule: "every day at 12 PM"
+              timezone: "UTC"
               backfill: true
               limit: 10
               webhook:
@@ -576,9 +574,7 @@ paths:
         - Entities
       summary: List entities
       description: |
-        Returns a paginated list of entities belonging to the authenticated
-        organization. Supports filtering by status and entity type, and
-        sorting by name, status, or creation date.
+        Returns a paginated list of entities belonging to the authenticated organization. Supports filtering by status and entity type, and sorting by name, status, or creation date.
       operationId: listEntities
       parameters:
         - $ref: "#/components/parameters/Page"
@@ -670,11 +666,9 @@ paths:
         - Entities
       summary: Create entities in batch
       description: |
-        Creates multiple entities in a single request. Each entity is
-        processed independently — a failure in one does not affect others.
+        Creates multiple entities in a single request. Each entity is processed independently — a failure in one does not affect others.
 
-        Returns an array of `{id, status}` objects in the same order as
-        the input array.
+        Returns an array of `{id, status}` objects in the same order as the input array.
       operationId: createEntitiesBatch
       requestBody:
         required: true
@@ -788,9 +782,7 @@ paths:
         - Datasets
       summary: List datasets
       description: |
-        Returns a paginated list of datasets belonging to the authenticated
-        organization. Supports filtering by status and sorting by name,
-        status, or creation date.
+        Returns a paginated list of datasets belonging to the authenticated organization. Supports filtering by status and sorting by name, status, or creation date.
       operationId: listDatasets
       parameters:
         - $ref: "#/components/parameters/Page"
@@ -877,9 +869,7 @@ paths:
         - Datasets
       summary: Create dataset from CSV
       description: |
-        Creates a new dataset by uploading a CSV file. Each row in the CSV
-        becomes an entity. The `name` column is required; all other columns
-        are optional.
+        Creates a new dataset by uploading a CSV file. Each row in the CSV becomes an entity. The `name` and `domain`columns are required; all other columns are optional.
 
         **CSV format:**
         ```csv
@@ -928,8 +918,7 @@ paths:
         - Datasets
       summary: Get dataset
       description:
-        Returns a single dataset by ID including entity count and current
-        status.
+        Returns a single dataset by ID including entity count and current status.
       operationId: getDataset
       parameters:
         - $ref: "#/components/parameters/DatasetId"
@@ -989,59 +978,6 @@ paths:
           $ref: "#/components/responses/NotFoundError"
 
   /catchAll/datasets/{dataset_id}/entities:
-    get:
-      tags:
-        - Datasets
-      summary: List entities in dataset
-      description: |
-        Returns a paginated list of entities in a dataset. Supports filtering by status and entity type.
-      operationId: listEntitiesInDataset
-      parameters:
-        - $ref: "#/components/parameters/DatasetId"
-        - $ref: "#/components/parameters/Page"
-        - name: page_size
-          in: query
-          required: false
-          schema:
-            type: integer
-            default: 100
-            minimum: 1
-            maximum: 500
-          description: Number of entities per page.
-        - name: search
-          in: query
-          required: false
-          schema:
-            type: string
-          description: Filter entities by name.
-        - name: status
-          in: query
-          required: false
-          schema:
-            $ref: "#/components/schemas/EntityStatus"
-        - name: entity_type
-          in: query
-          required: false
-          schema:
-            $ref: "#/components/schemas/EntityType"
-        - name: sort_by
-          in: query
-          required: false
-          schema:
-            $ref: "#/components/schemas/EntitySortBy"
-        - name: sort_order
-          in: query
-          required: false
-          schema:
-            $ref: "#/components/schemas/SortOrder"
-      responses:
-        "200":
-          $ref: "#/components/responses/DatasetEntityListResponse"
-        "403":
-          $ref: "#/components/responses/ForbiddenError"
-        "404":
-          $ref: "#/components/responses/NotFoundError"
-
     post:
       tags:
         - Datasets
@@ -1075,9 +1011,7 @@ paths:
         - Datasets
       summary: Remove entities from dataset
       description: |
-        Removes one or more entities from a dataset. The entities themselves
-        are not deleted — they are only removed from this dataset. Returns
-        the number of entities removed.
+        Removes one or more entities from a dataset. The entities themselves are not deleted — they are only removed from this dataset. Returns the number of entities removed.
       operationId: removeEntitiesFromDataset
       parameters:
         - $ref: "#/components/parameters/DatasetId"
@@ -1100,14 +1034,47 @@ paths:
         "422":
           $ref: "#/components/responses/ValidationError"
 
+  /catchAll/datasets/{dataset_id}/entities/list:
+    post:
+      tags:
+        - Datasets
+      summary: List entities in dataset
+      description: |
+        Returns a paginated list of entities in a dataset. Supports filtering by status, entity type, and name search.
+      operationId: listEntitiesInDataset
+      parameters:
+        - $ref: "#/components/parameters/DatasetId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ListDatasetEntitiesRequest"
+            example:
+              page: 1
+              page_size: 100
+              search: "OpenAI"
+              status: "ready"
+              entity_type: "company"
+              sort_by: "created_at"
+              sort_order: "desc"
+      responses:
+        "200":
+          $ref: "#/components/responses/DatasetEntityListResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
   /catchAll/datasets/{dataset_id}/status:
     get:
       tags:
         - Datasets
       summary: Get dataset status history
       description: |
-        Returns the full status change history for a dataset, ordered
-        chronologically from oldest to newest.
+        Returns the full status change history for a dataset, ordered chronologically from oldest to newest.
       operationId: getDatasetStatusHistory
       parameters:
         - $ref: "#/components/parameters/DatasetId"
@@ -1125,11 +1092,9 @@ paths:
         - Datasets
       summary: Add companies to dataset via CSV
       description: |
-        Appends new companies to an existing dataset by uploading a CSV file.
-        Uses the same CSV format as the dataset creation endpoint.
+        Appends new companies to an existing dataset by uploading a CSV file. Uses the same CSV format as the dataset creation endpoint.
 
-        The response omits `dataset_name` compared to the create-from-CSV
-        endpoint since the dataset already exists.
+        The response omits `dataset_name` compared to the create-from-CSV endpoint since the dataset already exists.
       operationId: uploadCSVToDataset
       parameters:
         - $ref: "#/components/parameters/DatasetId"
@@ -1266,7 +1231,6 @@ components:
       required: false
       schema:
         $ref: "#/components/schemas/OwnershipFilter"
-      description: Filter results by ownership. Defaults to `all`.
 
   responses:
     InitializeResponse:
@@ -1838,6 +1802,13 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
 
+    NotAllowedError:
+      description: HTTP method not allowed on this endpoint
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+
     ValidationError:
       description: Validation error
       content:
@@ -2113,11 +2084,21 @@ components:
             type: string
             format: uuid
           description: |
-            Dataset IDs to connect to this job. When provided, activates Company Watchlist mode — the job returns only events relevant to companies in the connected datasets with each record including a `connected_entities` array scored per company.
+            Dataset IDs to connect to the job. When provided, this enables Company Watchlist mode — the job returns only events relevant to companies in the connected datasets. To set the minimum relevance threshold, use `ed_score_min`.
 
             The dataset must have `latest_status: ready` before the job is submitted. Submitting with a non-existent or inaccessible dataset ID returns `400`.
           example:
             - "ccabb755-afc2-4047-b84c-78d1f23d49b2"
+        ed_score_min:
+          type: integer
+          minimum: 1
+          maximum: 10
+          default: 2
+          description: |
+            The minimum relevance score a connected entity must reach for its record to be included in results.
+
+            Only valid when `connected_dataset_ids` is set; otherwise ignored. Records where no connected entity meets the threshold are excluded entirely.
+          example: 3
 
     SubmitResponseDto:
       type: object
@@ -2627,10 +2608,16 @@ components:
         schedule:
           type: string
           description: |
-            Monitor schedule in plain text format (e.g. 'every day at 12 PM UTC', 'every 48 hours').
-
-            Minimum frequency depends on your plan.
+            Monitor schedule in plain text format. Minimum frequency depends on your plan.
           example: "every day at 12 PM UTC"
+        timezone:
+          type: string
+          description: |
+            The IANA timezone identifier used as the fallback when the `schedule` string does not include an explicit timezone.
+
+            If the schedule includes a timezone abbreviation (for example, `"every day at 9am EST"`), the parsed timezone takes priority and this value is ignored. 
+          example: "America/New_York"
+          default: "UTC"
         webhook:
           $ref: "#/components/schemas/WebhookDto"
           description:
@@ -3702,6 +3689,35 @@ components:
           example:
             - "854198fa-f702-49db-a381-0427fa87f173"
 
+    ListDatasetEntitiesRequest:
+      type: object
+      properties:
+        page:
+          type: integer
+          minimum: 1
+          default: 1
+          description: The page number to retrieve.
+          example: 1
+        page_size:
+          type: integer
+          minimum: 1
+          maximum: 500
+          default: 100
+          description: The number of entities per page.
+          example: 100
+        search:
+          type: string
+          description: Filters entities by name using a case-insensitive substring match.
+          example: "OpenAI"
+        status:
+          $ref: "#/components/schemas/EntityStatus"
+        entity_type:
+          $ref: "#/components/schemas/EntityType"
+        sort_by:
+          $ref: "#/components/schemas/EntitySortBy"
+        sort_order:
+          $ref: "#/components/schemas/SortOrder"
+
     ManageEntitiesResponse:
       type: object
       required:
@@ -3787,14 +3803,13 @@ components:
       required:
         - entity_id
         - name
+        - type
         - ed_score
         - relation
       description: |
-        A company entity matched to a record in a Company Watchlist job, with
-        a relevance score and explanation.
+        A company entity matched to a record in a Company Watchlist job, with a relevance score and explanation.
 
-        Only entities with `ed_score` ≥ 1 appear in results. Entities scored
-        0 are filtered out before the response is returned.
+        Only entities with `ed_score` ≥ 1 appear in results. Entities scored 0 are filtered out before the response is returned. When `ed_score_min` is set at submission time, entities below that threshold are excluded.
       properties:
         entity_id:
           type: string
@@ -3810,8 +3825,7 @@ components:
           minimum: 1
           maximum: 10
           description: |
-            Relevance score indicating how directly the entity is associated
-            with this event.
+            Relevance score indicating how directly the entity is associated with this event.
 
             | Score | Meaning |
             |-------|---------|
@@ -3824,11 +3838,21 @@ components:
           type: string
           maxLength: 100
           description: |
-            Short explanation (up to 100 characters) of why this entity is
-            associated with the event.
+            Short explanation (up to 100 characters) of why this entity is associated with the event.
           example:
-            "Lucid Gravity is positioned as a direct competitor to the Tesla
-            Model X."
+            "Lucid Gravity is positioned as a direct competitor to the Tesla Model X."
+        type:
+          type: string
+          description: |
+            The entity type.
+          example: "company"
+        company:
+          allOf:
+            - $ref: "#/components/schemas/CompanyAttributes"
+          description: |
+            The stored attributes for this entity. Present only when attributes exist in the database. 
+            
+            The field name matches the value of `type` — for example, `"company"` type entities have a `company` field.
 
     GetPlanLimitsResponseDto:
       type: object

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -1802,13 +1802,6 @@ components:
           schema:
             $ref: "#/components/schemas/Error"
 
-    NotAllowedError:
-      description: HTTP method not allowed on this endpoint
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/Error"
-
     ValidationError:
       description: Validation error
       content:

--- a/web-search-api/api-reference/datasets/list-entities-in-dataset.mdx
+++ b/web-search-api/api-reference/datasets/list-entities-in-dataset.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: catch-all-api get /catchAll/datasets/{dataset_id}/entities
+openapi: catch-all-api post /catchAll/datasets/{dataset_id}/entities/list
 ---

--- a/web-search-api/get-started/changelog.mdx
+++ b/web-search-api/get-started/changelog.mdx
@@ -5,6 +5,37 @@ description: Track updates, improvements, and fixes to the CatchAll API.
 rss: true
 ---
 
+<Update label="1.5.3" description="2026-05-11">
+## ED score filtering, entity attributes, and monitor timezone
+
+Refines Company Watchlist with relevance threshold control and richer entity 
+data in results; adds timezone support for monitor scheduling.
+
+**Features:**
+
+- **ED score filtering**: Submit jobs with `ed_score_min` to exclude connected 
+  entities below a relevance threshold. Only records where at least one entity 
+  meets the minimum score are returned.
+- **Entity attributes in results**: Each matched entity in `connected_entities`
+  now includes a `type` field and a `company` object with domain, alternative
+  names, and key persons.
+- **Monitor timezone**: Set an explicit IANA timezone on monitor creation with
+  the new `timezone` parameter. Used as the fallback when the schedule string
+  does not include one. Defaults to `"UTC"`.
+
+**Changed:**
+
+- [`POST /catchAll/datasets/{dataset_id}/entities/list`](/web-search-api/api-reference/datasets/list-entities-in-dataset)
+  replaces `GET /catchAll/datasets/{dataset_id}/entities` for listing entities.
+  Pagination and filter parameters are now accepted in the request body.
+- [`POST /catchAll/datasets/upload`](/web-search-api/api-reference/datasets/create-dataset-from-csv)
+  and
+  [`POST /catchAll/datasets/{dataset_id}/upload`](/web-search-api/api-reference/datasets/upload-csv-to-dataset)
+  now require a `domain` column. A missing column header returns `422`. Rows
+  where `domain` is empty are skipped and reported in `validation_report`.
+
+</Update>
+
 <Update label="1.5.0" description="2026-04-22">
 ## Resource management and sharing
 

--- a/web-search-api/get-started/introduction.mdx
+++ b/web-search-api/get-started/introduction.mdx
@@ -245,7 +245,7 @@ CatchAll processes queries through a multi-stage pipeline that analyzes over
     | `/catchAll/datasets/{dataset_id}`               | `DELETE` | Delete dataset                           |
     | `/catchAll/datasets/{dataset_id}/entities`      | `POST`   | Add entities to dataset                  |
     | `/catchAll/datasets/{dataset_id}/entities`      | `DELETE` | Remove entities from dataset             |
-    | `/catchAll/datasets/{dataset_id}/entities`      | `GET`    | List entities in dataset                 |
+    | `/catchAll/datasets/{dataset_id}/entities/list` | `POST`    | List entities in dataset                 |
     | `/catchAll/datasets/{dataset_id}/status`        | `GET`    | Get dataset status history               |
     | `/catchAll/datasets/{dataset_id}/upload`        | `POST`   | Add companies to dataset via CSV         |
   </Tab>

--- a/web-search-api/guides-and-concepts/company-search.mdx
+++ b/web-search-api/guides-and-concepts/company-search.mdx
@@ -432,9 +432,9 @@ String datasetId = dataset.getId();
 Upload a CSV to create both entities and the dataset in a single request —
 the fastest path for most use cases.
 
-The `name` column is required; all other columns are optional. Use semicolons
-to separate multiple values in `alternative_names` and `key_persons`. Rows
-with an empty `name` are skipped and reported in `validation_report`.
+The `name` and `domain` columns are required; all other columns are optional. 
+Use semicolons to separate multiple values in `alternative_names` and `key_persons`. 
+Rows with an empty `name` are skipped and reported in `validation_report`.
 
 ```csv
 name,description,domain,alternative_names,key_persons
@@ -729,8 +729,21 @@ results.getAllRecords().forEach(record -> {
         {
           "entity_id": "854198fa-f702-49db-a381-0427fa87f173",
           "name": "NewsCatcher",
+          "type": "company",
           "ed_score": 9,
-          "relation": "NewsCatcher is a named partner in the announced AI infrastructure deal"
+          "relation": "NewsCatcher is a named partner in the announced AI infrastructure deal",
+          "company": {
+            "domain": "newscatcherapi.com",
+            "description": "AI-powered news data provider",
+            "alternative_names": [
+              "NC",
+              "NewsCatcher API"
+            ],
+            "key_persons": [
+              "Artem Bugara",
+              "Maksym Sugonyaka"
+            ]
+          }
         }
       ]
     }


### PR DESCRIPTION
## What

Updates the OAS and related MDX pages from v1.5.0 to v1.5.3.

## Changes

- Remove `GET /catchAll/datasets/{dataset_id}/entities`; add `POST /catchAll/datasets/{dataset_id}/entities/list` with `ListDatasetEntitiesRequest` schema
- Add `ed_score_min` to `SubmitJobRequestDto`
- Add `timezone` to `CreateMonitorRequestDto`
- Add `type` and `company` (`allOf` + `$ref: CompanyAttributes`) to `ConnectedEntity`; update `required` array
- Update both CSV upload endpoint descriptions — `domain` is now required; update `SkippedRow.reason` example
- Update `list-entities-in-dataset.mdx` frontmatter to point to the new POST route
- Update Company Watchlist guide — `domain` required in CSV format note; add `type` and `company` to `connected_entities` response example and field table
- Bump `info.version` to `"1.5.3"`

## Testing

- [x] Manually tested against live API — GET /entities confirmed 405, POST /entities/list confirmed 200, dataset-connected job with `ed_score_min` confirmed filtering, monitor with `timezone` confirmed stored correctly