### PR TITLE
docs(catch-all-api): add v1.6.0 documentation — webhooks, query validation, and projects

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -105,6 +105,7 @@
                   "web-search-api/api-reference/webhooks/list-webhook-resources",
                   "web-search-api/api-reference/webhooks/remove-resource",
                   "web-search-api/api-reference/webhooks/list-resource-webhooks",
+                  "web-search-api/api-reference/webhooks/get-delivery-history",
                   "web-search-api/api-reference/webhooks/webhook-payload"
                 ]
               },

--- a/docs.json
+++ b/docs.json
@@ -57,6 +57,7 @@
             "group": "How to",
             "pages": [
               "web-search-api/how-to/write-effective-queries",
+              "web-search-api/how-to/set-up-webhooks",
               "web-search-api/how-to/configure-monitors",
               "web-search-api/how-to/troubleshoot-monitors"
             ]

--- a/docs.json
+++ b/docs.json
@@ -67,6 +67,7 @@
               {
                 "group": "Jobs",
                 "pages": [
+                  "web-search-api/api-reference/jobs/validate-query",
                   "web-search-api/api-reference/jobs/initialize-job",
                   "web-search-api/api-reference/jobs/create-job",
                   "web-search-api/api-reference/jobs/get-job-status",

--- a/docs.json
+++ b/docs.json
@@ -119,6 +119,20 @@
                 ]
               },
               {
+                "group": "Projects",
+                "pages": [
+                  "web-search-api/api-reference/projects/list-projects",
+                  "web-search-api/api-reference/projects/create-project",
+                  "web-search-api/api-reference/projects/get-project",
+                  "web-search-api/api-reference/projects/update-project",
+                  "web-search-api/api-reference/projects/delete-project",
+                  "web-search-api/api-reference/projects/get-project-overview",
+                  "web-search-api/api-reference/projects/list-resources",
+                  "web-search-api/api-reference/projects/add-resource",
+                  "web-search-api/api-reference/projects/remove-resource"
+                ]
+              },
+              {
                 "group": "Meta",
                 "pages": [
                   "web-search-api/api-reference/meta/health",

--- a/docs.json
+++ b/docs.json
@@ -88,8 +88,23 @@
                   "web-search-api/api-reference/monitors/enable-monitor",
                   "web-search-api/api-reference/monitors/disable-monitor",
                   "web-search-api/api-reference/monitors/update-monitor",
-                  "web-search-api/api-reference/monitors/delete-monitor",
-                  "web-search-api/api-reference/monitors/webhook-payload"
+                  "web-search-api/api-reference/monitors/delete-monitor"
+                ]
+              },
+              {
+                "group": "Webhooks",
+                "pages": [
+                  "web-search-api/api-reference/webhooks/create-webhook",
+                  "web-search-api/api-reference/webhooks/list-webhooks",
+                  "web-search-api/api-reference/webhooks/get-webhook",
+                  "web-search-api/api-reference/webhooks/update-webhook",
+                  "web-search-api/api-reference/webhooks/delete-webhook",
+                  "web-search-api/api-reference/webhooks/test-webhook",
+                  "web-search-api/api-reference/webhooks/assign-resource",
+                  "web-search-api/api-reference/webhooks/list-webhook-resources",
+                  "web-search-api/api-reference/webhooks/remove-resource",
+                  "web-search-api/api-reference/webhooks/list-resource-webhooks",
+                  "web-search-api/api-reference/webhooks/webhook-payload"
                 ]
               },
               {

--- a/docs.json
+++ b/docs.json
@@ -48,6 +48,7 @@
               "web-search-api/guides-and-concepts/jobs",
               "web-search-api/guides-and-concepts/monitors",
               "web-search-api/guides-and-concepts/company-search",
+              "web-search-api/guides-and-concepts/projects",
               "web-search-api/guides-and-concepts/index-and-search-depth",
               "web-search-api/guides-and-concepts/dynamic-schemas"
             ]

--- a/llms.txt
+++ b/llms.txt
@@ -17,6 +17,7 @@
 - [Jobs](https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/jobs): How CatchAll jobs work and how to move from query to results.
 - [Monitors](https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/monitors): Schedule recurring CatchAll jobs with webhook notifications.
 - [Company Watchlist](https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/company-search): Track specific companies across CatchAll jobs with per-company relevance scores.
+- [Projects](https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/projects): Organize jobs, monitors, and datasets into named groups for easier management and sharing.
 - [Understanding web index and search depth](https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/index-and-search-depth): How CatchAll's web index works and what start_date and end_date actually control.
 - [Working with dynamic schemas](https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/dynamic-schemas): Build integrations that handle variable field names and structures.
 
@@ -130,6 +131,27 @@ undone.
 - [Upload Csv To Dataset](https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/upload-csv-to-dataset): Appends new companies to an existing dataset by uploading a CSV file. Uses the same CSV format as the dataset creation endpoint.
 
 The response omits `dataset_name` compared to the create-from-CSV endpoint since the dataset already exists.
+
+
+### API Reference — Projects
+
+- [List Projects](https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/list-projects): Returns all projects visible to the authenticated user.
+- [Create Project](https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/create-project): Creates a new project.
+- [Get Project](https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/get-project): Returns a single project by ID.
+- [Update Project](https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/update-project): Updates the name or description of an existing project.
+- [Delete Project](https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/delete-project): Deletes a project. By default, assigned resources are unassigned but not deleted. 
+
+- [Get Project Overview](https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/get-project-overview): Returns resource counts for a project, grouped by type and status.
+
+For `jobs` and `monitors`, counts are broken down by status (for example, `completed`, `failed`). For `datasets` and `monitor_groups`, only a `total` count is returned.
+
+- [List Resources](https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/list-resources): Returns all resources assigned to a project, with optional filtering by type.
+- [Add Resource](https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/add-resource): Assigns an existing resource to a project.
+
+The operation is idempotent — if the resource is already assigned, the response is `200` with `already_exists: true`.
+
+- [Remove Resource](https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/remove-resource): Removes a resource from a project. The resource itself is not
+deleted — it becomes unassigned and continues to exist.
 
 
 ### API Reference — Meta

--- a/llms.txt
+++ b/llms.txt
@@ -24,6 +24,7 @@
 ### How to
 
 - [Write effective queries](https://www.newscatcherapi.com/docs/web-search-api/how-to/write-effective-queries): Construct queries that produce high-quality event records.
+- [Set up webhooks](https://www.newscatcherapi.com/docs/web-search-api/how-to/set-up-webhooks): Create and manage webhooks to receive real-time notifications when jobs and monitors complete.
 - [Configure monitors](https://www.newscatcherapi.com/docs/web-search-api/how-to/configure-monitors): Configure reliable, efficient monitors and optimize performance.
 - [Troubleshoot monitors](https://www.newscatcherapi.com/docs/web-search-api/how-to/troubleshoot-monitors): Diagnose and fix common monitor issues.
 

--- a/llms.txt
+++ b/llms.txt
@@ -29,6 +29,10 @@
 
 ### API Reference — Jobs
 
+- [Validate Query](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/validate-query): Checks whether a query is well-formed and likely to produce good results before submitting a job.
+
+Returns a quality assessment with a status level, identified issues, and actionable suggestions.
+
 - [Initialize Job](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/initialize-job): Get suggested validators, enrichments, and date ranges for a query.
 - [Create Job](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/create-job): Submit a query to create a new processing job.
 - [Get Job Status](https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/get-job-status): Retrieve the current processing status of a job.
@@ -63,7 +67,42 @@ monitor is not found or does not belong to the authenticated user.
 
 Deleting an already-deleted monitor returns `200`.
 
-- [Webhook payload](https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/webhook-payload): Data model for a payload sent to the webhook URL when a monitor job completes.
+
+### API Reference — Webhooks
+
+- [Create Webhook](https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/create-webhook): Creates a new webhook endpoint for the organization.
+
+- [List Webhooks](https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/list-webhooks): Returns a paginated list of webhooks belonging to the organization.
+- [Get Webhook](https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/get-webhook): Returns the full configuration of a single webhook by ID.
+- [Update Webhook](https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/update-webhook): Updates one or more fields of an existing webhook.
+
+- [Delete Webhook](https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/delete-webhook): Permanently deletes a webhook and removes all resource assignments. 
+
+Assigned jobs and monitors no longer trigger delivery to this webhook. This operation cannot be undone.
+
+- [Test Webhook](https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/test-webhook): Sends a test HTTP request to the webhook URL using the webhook's configured method, headers, and auth. Returns the response from the target endpoint.
+
+Use this to verify URL reachability and authentication before attaching the webhook to a live job or monitor.
+
+- [Assign Resource](https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/assign-resource): Attaches a job, monitor, or monitor group to the webhook. When the
+resource completes, the webhook receives a delivery.
+
+A single webhook can be assigned to multiple resources. Each resource
+can have up to 5 webhooks assigned.
+
+- [List Webhook Resources](https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/list-webhook-resources): Returns a paginated list of resources currently assigned to this webhook.
+
+- [Remove Resource](https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/remove-resource): Detaches a resource from this webhook. Completions of the resource no longer trigger delivery to this webhook.
+
+The webhook and the resource itself are not deleted.
+
+- [List Resource Webhooks](https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/list-resource-webhooks): Returns all webhooks currently assigned to the given resource.
+
+- [Get Delivery History](https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/get-delivery-history): Returns a paginated delivery log for a given resource, ordered by timestamp descending. 
+
+Each record shows the webhook dispatched, the HTTP status code returned, delivery outcome, and any error or warning messages. Use this to debug failed deliveries or audit dispatch activity.
+
+- [Webhook payload](https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/webhook-payload): Data model for the payload delivered to a webhook when a monitor job completes.
 
 ### API Reference — Entities
 

--- a/llms.txt
+++ b/llms.txt
@@ -146,9 +146,7 @@ The response omits `dataset_name` compared to the create-from-CSV endpoint since
 For `jobs` and `monitors`, counts are broken down by status (for example, `completed`, `failed`). For `datasets` and `monitor_groups`, only a `total` count is returned.
 
 - [List Resources](https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/list-resources): Returns all resources assigned to a project, with optional filtering by type.
-- [Add Resource](https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/add-resource): Assigns an existing resource to a project.
-
-The operation is idempotent — if the resource is already assigned, the response is `200` with `already_exists: true`.
+- [Add Resource](https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/add-resource): Assigns one or more existing resources to a project in a single request.
 
 - [Remove Resource](https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/remove-resource): Removes a resource from a project. The resource itself is not
 deleted — it becomes unassigned and continues to exist.

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -22,6 +22,9 @@
         <loc>https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/company-search</loc>
     </url>
     <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/projects</loc>
+    </url>
+    <url>
         <loc>https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/index-and-search-depth</loc>
     </url>
     <url>
@@ -140,6 +143,33 @@
     </url>
     <url>
         <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/datasets/upload-csv-to-dataset</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/list-projects</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/create-project</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/get-project</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/update-project</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/delete-project</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/get-project-overview</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/list-resources</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/add-resource</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/projects/remove-resource</loc>
     </url>
     <url>
         <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/meta/health</loc>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -34,6 +34,9 @@
         <loc>https://www.newscatcherapi.com/docs/web-search-api/how-to/write-effective-queries</loc>
     </url>
     <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/how-to/set-up-webhooks</loc>
+    </url>
+    <url>
         <loc>https://www.newscatcherapi.com/docs/web-search-api/how-to/configure-monitors</loc>
     </url>
     <url>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -40,6 +40,9 @@
         <loc>https://www.newscatcherapi.com/docs/web-search-api/how-to/troubleshoot-monitors</loc>
     </url>
     <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/validate-query</loc>
+    </url>
+    <url>
         <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/initialize-job</loc>
     </url>
     <url>
@@ -91,7 +94,40 @@
         <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/delete-monitor</loc>
     </url>
     <url>
-        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/monitors/webhook-payload</loc>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/create-webhook</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/list-webhooks</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/get-webhook</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/update-webhook</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/delete-webhook</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/test-webhook</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/assign-resource</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/list-webhook-resources</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/remove-resource</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/list-resource-webhooks</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/get-delivery-history</loc>
+    </url>
+    <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/webhooks/webhook-payload</loc>
     </url>
     <url>
         <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/entities/list-entities</loc>

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -609,7 +609,7 @@ paths:
               $ref: "#/components/schemas/CreateWebhookRequestDto"
             example:
               name: "Layoffs Alert"
-              url: "https://hooks.slack.com/services/T000/B000/xxxx"
+              url: "https://hooks.slack.com/services/T000/B000/xxx"
               type: "slack"
               delivery_mode: "full"
       responses:
@@ -2334,7 +2334,7 @@ components:
             webhook:
               id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
               name: "Layoffs Alert"
-              url: "https://hooks.slack.com/services/T000/B000/xxxx"
+              url: "https://hooks.slack.com/services/T000/B000/xxx"
               type: "slack"
               delivery_mode: "full"
               method: "POST"
@@ -2359,7 +2359,7 @@ components:
             webhook:
               id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
               name: "Layoffs Alert"
-              url: "https://hooks.slack.com/services/T000/B000/xxxx"
+              url: "https://hooks.slack.com/services/T000/B000/xxx"
               type: "slack"
               delivery_mode: "full"
               method: "POST"
@@ -2411,7 +2411,7 @@ components:
             webhooks:
               - id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
                 name: "Layoffs Alert"
-                url: "https://hooks.slack.com/services/T000/B000/xxxx"
+                url: "https://hooks.slack.com/services/T000/B000/xxx"
                 type: "slack"
                 delivery_mode: "full"
                 method: "POST"
@@ -2500,7 +2500,7 @@ components:
             webhooks:
               - id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
                 name: "Layoffs Alert"
-                url: "https://hooks.slack.com/services/T000/B000/xxxx"
+                url: "https://hooks.slack.com/services/T000/B000/xxx"
                 type: "slack"
                 delivery_mode: "full"
                 method: "POST"
@@ -3541,14 +3541,6 @@ components:
             Maximum 5 per monitor.
           example:
             - "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-        webhook:
-          deprecated: true
-          description: |
-            **Deprecated.** Use `webhook_ids` instead.
-
-            Inline webhook configuration kept for backward compatibility. Do not use both `webhook` and `webhook_ids` in the same request.
-          allOf:
-            - $ref: "#/components/schemas/WebhookDto"
         limit:
           type: integer
           minimum: 10
@@ -3726,7 +3718,7 @@ components:
           type: string
           format: uri
           description: Destination URL that receives the payload.
-          example: "https://hooks.slack.com/services/T000/B000/xxxx"
+          example: "https://hooks.slack.com/services/T000/B000/xxx"
         type:
           $ref: "#/components/schemas/WebhookType"
         delivery_mode:
@@ -3796,7 +3788,7 @@ components:
             - `custom`: Any valid HTTPS domain.
 
             When `type` is omitted, it is auto-detected from the URL.
-          example: "https://hooks.slack.com/services/T000/B000/xxxx"
+          example: "https://hooks.slack.com/services/T000/B000/xxx"
         type:
           $ref: "#/components/schemas/WebhookType"
         delivery_mode:
@@ -3836,7 +3828,7 @@ components:
           description: Custom payload transformation configuration. Required only when `type` is `custom`.
       example:
         name: "Layoffs Alert"
-        url: "https://hooks.slack.com/services/T000/B000/xxxx"
+        url: "https://hooks.slack.com/services/T000/B000/xxx"
         type: "slack"
         delivery_mode: "full"
 
@@ -4144,12 +4136,6 @@ components:
           type: integer
           minimum: 10
           description: Updated maximum number of records per monitor run.
-        webhook:
-          deprecated: true
-          description: |
-            **Deprecated.** Use `webhook_ids` instead.
-
-            Inline webhook configuration kept for backward compatibility. Do not use both `webhook` and `webhook_ids` in the same request.
 
     UpdateMonitorResponseDto:
       type: object

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -542,11 +542,8 @@ paths:
             schema:
               $ref: "#/components/schemas/UpdateMonitorRequestDto"
             example:
-              webhook:
-                url: "https://new-endpoint.com/webhook"
-                method: "POST"
-                headers:
-                  Authorization: "Bearer new_token_xyz"
+              webhook_ids:
+                - "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
       responses:
         "200":
           $ref: "#/components/responses/UpdateMonitorResponse"
@@ -4116,15 +4113,27 @@ components:
     UpdateMonitorRequestDto:
       type: object
       properties:
-        webhook:
-          $ref: "#/components/schemas/WebhookDto"
+        webhook_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
           description: |
-            Updated webhook configuration.
+            Updated list of centralized webhook IDs for this monitor. 
+            
+            Replaces all existing webhook assignments. Pass an empty array `[]` to clear all assignments. Omit to leave existing assignments unchanged.
+          example:
+            - "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
         limit:
           type: integer
           minimum: 10
+          description: Updated maximum number of records per monitor run.
+        webhook:
+          deprecated: true
           description: |
-            Updated maximum number of records per monitor run.
+            **Deprecated.** Use `webhook_ids` instead.
+
+            Inline webhook configuration kept for backward compatibility. Do not use both `webhook` and `webhook_ids` in the same request.
 
     UpdateMonitorResponseDto:
       type: object

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -330,11 +330,8 @@ paths:
               timezone: "UTC"
               backfill: true
               limit: 10
-              webhook:
-                url: "https://your-endpoint.com/webhook"
-                method: "POST"
-                headers:
-                  Authorization: "Bearer your_token_here"
+              webhook_ids:
+                - "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
       responses:
         "200":
           $ref: "#/components/responses/CreateMonitorResponse"
@@ -3519,10 +3516,26 @@ components:
             If the schedule includes a timezone abbreviation (for example, `"every day at 9am EST"`), the parsed timezone takes priority and this value is ignored. 
           example: "America/New_York"
           default: "UTC"
+        webhook_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: |
+            IDs of centralized webhooks to notify on each run completion.
+            Passing IDs here is equivalent to calling
+            `POST /catchAll/webhooks/{webhook_id}/resources` for each ID after creation.
+            Maximum 5 per monitor.
+          example:
+            - "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
         webhook:
-          $ref: "#/components/schemas/WebhookDto"
-          description:
-            Optional webhook to receive notifications when jobs complete.
+          deprecated: true
+          description: |
+            **Deprecated.** Use `webhook_ids` instead.
+
+            Inline webhook configuration kept for backward compatibility. Do not use both `webhook` and `webhook_ids` in the same request.
+          allOf:
+            - $ref: "#/components/schemas/WebhookDto"
         limit:
           type: integer
           minimum: 10

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -3788,6 +3788,64 @@ components:
         - FAILED
       description: Outcome of a webhook delivery attempt.
 
+    DeliveryHistoryItemDto:
+      type: object
+      required:
+        - id
+        - webhook_id
+        - resource_type
+        - resource_id
+        - status_code
+        - attempt_number
+        - timestamp
+        - delivery_status
+      properties:
+        id:
+          type: integer
+          description: Delivery record identifier.
+          example: 42
+        webhook_id:
+          type: string
+          format: uuid
+          description: Identifier of the webhook that was dispatched.
+          example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        resource_type:
+          $ref: "#/components/schemas/MappableResourceType"
+          description: Type of the resource that triggered the delivery.
+        resource_id:
+          type: string
+          format: uuid
+          description: Identifier of the resource that triggered the delivery.
+          example: "3fec5b07-8786-46d7-9486-d43ff67eccd4"
+        additional_info:
+          type: object
+          description: Extra context about the triggering event, such as job query or monitor schedule.
+          example: {}
+        status_code:
+          type: integer
+          description: HTTP response code returned by the webhook endpoint.
+          example: 200
+        attempt_number:
+          type: integer
+          description: Delivery attempt number. 1 indicates the first attempt.
+          example: 1
+        timestamp:
+          type: string
+          format: date-time
+          description: Time of the delivery attempt in ISO 8601 format with UTC timezone.
+          example: "2026-05-18T10:00:00Z"
+        delivery_status:
+          $ref: "#/components/schemas/DeliveryStatus"
+          description: Outcome of this delivery attempt.
+        error_message:
+          type: ["string", "null"]
+          description: Error detail when `delivery_status` is `FAILED`. Null on success.
+          example: null
+        warning_message:
+          type: ["string", "null"]
+          description: Non-fatal warning, such as payload truncation notices. Null when no warnings occurred.
+          example: null
+
     BearerAuthDto:
       type: object
       required:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -3135,7 +3135,7 @@ components:
         - DELETE
       description: HTTP method used for webhook delivery.
 
-      MappableResourceType:
+    MappableResourceType:
       type: string
       enum:
         - job
@@ -3143,7 +3143,7 @@ components:
         - monitor_group
       description: Resource types that can be assigned to a webhook.
 
-      BearerAuthDto:
+    BearerAuthDto:
       type: object
       required:
         - type
@@ -3271,6 +3271,73 @@ components:
           format: date-time
           description: Timestamp of the last update in ISO 8601 format with UTC timezone.
           example: "2026-05-18T10:00:00Z"
+
+    CreateWebhookRequestDto:
+      type: object
+      required:
+        - name
+        - url
+      properties:
+        name:
+          type: string
+          description: Human-readable label for this webhook.
+          example: "Layoffs Alert"
+        url:
+          type: string
+          format: uri
+          description: |
+            Destination URL that receives the payload. Must use HTTPS. IP addresses are not accepted.
+
+            Type-specific URL requirements:
+            - `slack`: Must start with `https://hooks.slack.com/`.
+            - `teams`: Hostname must match `*.webhook.office.com` or `*.webhook.office365.com`.
+            - `generic`: Any valid HTTPS domain.
+            - `custom`: Any valid HTTPS domain.
+
+            When `type` is omitted, it is auto-detected from the URL.
+          example: "https://hooks.slack.com/services/T000/B000/xxxx"
+        type:
+          $ref: "#/components/schemas/WebhookType"
+        delivery_mode:
+          $ref: "#/components/schemas/DeliveryMode"
+        method:
+          $ref: "#/components/schemas/HttpMethod"
+        headers:
+          type: object
+          additionalProperties:
+            type: string
+          description: Custom HTTP headers forwarded with each delivery.
+          default: {}
+        params:
+          type: object
+          additionalProperties:
+            type: string
+          description: Query parameters appended to the webhook URL.
+          default: {}
+        auth:
+          oneOf:
+            - $ref: "#/components/schemas/BearerAuthDto"
+            - $ref: "#/components/schemas/ApiKeyAuthDto"
+            - $ref: "#/components/schemas/BasicAuthDto"
+          discriminator:
+            propertyName: type
+            mapping:
+              bearer: "#/components/schemas/BearerAuthDto"
+              api_key: "#/components/schemas/ApiKeyAuthDto"
+              basic: "#/components/schemas/BasicAuthDto"
+          description: |
+            Authentication forwarded with each delivery. Supported types:
+            - `bearer`: Adds an `Authorization: Bearer <token>` header.
+            - `api_key`: Adds a custom header with the specified name and value.
+            - `basic`: Adds an `Authorization: Basic <credentials>` header.
+        formatter_config:
+          type: ["object", "null"]
+          description: Custom payload transformation configuration. Required only when `type` is `custom`.
+      example:
+        name: "Layoffs Alert"
+        url: "https://hooks.slack.com/services/T000/B000/xxxx"
+        type: "slack"
+        delivery_mode: "full"
 
     CreateMonitorResponseDto:
       type: object

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -140,6 +140,32 @@ paths:
         "403":
           $ref: "#/components/responses/ForbiddenError"
 
+  /catchAll/validate:
+    post:
+      tags:
+        - Jobs
+      summary: Validate query
+      description: |
+        Checks whether a query is well-formed and likely to produce good results before submitting a job.
+
+        Returns a quality assessment with a status level, identified issues, and actionable suggestions.
+      operationId: validateQuery
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ValidateQueryRequestDto"
+            example:
+              query: "Series B funding rounds for SaaS startups"
+      responses:
+        "200":
+          $ref: "#/components/responses/ValidateQueryResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
   /catchAll/initialize:
     post:
       tags:
@@ -1831,7 +1857,7 @@ components:
             issues: []
             suggestions: []
             confidence: 0.98
-            
+
     InitializeResponse:
       description: Suggestions retrieved successfully
       content:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -22,6 +22,13 @@ info:
     2. Create monitor via /catchAll/monitors/create with schedule
     3. Retrieve aggregated results via /catchAll/monitors/pull/{monitor_id}
 
+    ### Webhook workflow
+
+    1. Create a webhook via `POST /catchAll/webhooks`
+    2. Attach it to a job or monitor via `POST /catchAll/webhooks/{webhook_id}/resources`,
+       or pass `webhook_ids` at job or monitor creation time
+    3. Receive HTTP notifications at the configured URL when each job completes
+
     ### Company search workflow
 
     1. Create a dataset via `POST /catchAll/datasets/` or `POST /catchAll/datasets/upload`

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -898,6 +898,51 @@ paths:
         "422":
           $ref: "#/components/responses/ValidationError"
 
+  /catchAll/webhook-history:
+    get:
+      tags:
+        - Webhooks
+      summary: Get delivery history
+      description: |
+        Returns a paginated delivery log for a given resource, ordered by timestamp descending. 
+        
+        Each record shows the webhook dispatched, the HTTP status code returned, delivery outcome, and any error or warning messages. Use this to debug failed deliveries or audit dispatch activity.
+      operationId: getWebhookDeliveryHistory
+      parameters:
+        - name: resource_type
+          in: query
+          required: true
+          schema:
+            $ref: "#/components/schemas/MappableResourceType"
+          description: Type of the resource to retrieve delivery history for.
+        - name: resource_id
+          in: query
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Identifier of the resource to retrieve delivery history for.
+          example: "3fec5b07-8786-46d7-9486-d43ff67eccd4"
+        - $ref: "#/components/parameters/Page"
+        - name: page_size
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 500
+          description: Number of records per page.
+      responses:
+        "200":
+          $ref: "#/components/responses/DeliveryHistoryResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
   # ── Entities ──────────────────────────────────────────────────────────────
 
   /catchAll/entities:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -3339,6 +3339,60 @@ components:
         type: "slack"
         delivery_mode: "full"
 
+    CreateWebhookResponseDto:
+      type: object
+      required:
+        - success
+        - message
+      properties:
+        success:
+          type: boolean
+          description: True if the webhook was created; false otherwise.
+          example: true
+        message:
+          type: string
+          description: Human-readable result message.
+          example: "Webhook created successfully."
+        webhook:
+          $ref: "#/components/schemas/WebhookResponseDto"
+          description: The created webhook object.
+
+    GetWebhookResponseDto:
+      type: object
+      required:
+        - success
+        - message
+      properties:
+        success:
+          type: boolean
+          description: True if the operation succeeded; false otherwise.
+          example: true
+        message:
+          type: string
+          description: Human-readable result message.
+          example: "Webhook retrieved successfully."
+        webhook:
+          $ref: "#/components/schemas/WebhookResponseDto"
+          description: The retrieved webhook object.
+
+    UpdateWebhookResponseDto:
+      type: object
+      required:
+        - success
+        - message
+      properties:
+        success:
+          type: boolean
+          description: True if the webhook was updated; false otherwise.
+          example: true
+        message:
+          type: string
+          description: Human-readable result message.
+          example: "Webhook updated successfully."
+        webhook:
+          $ref: "#/components/schemas/WebhookResponseDto"
+          description: The updated webhook object.
+
     CreateMonitorResponseDto:
       type: object
       required:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -3135,6 +3135,14 @@ components:
         - DELETE
       description: HTTP method used for webhook delivery.
 
+      MappableResourceType:
+      type: string
+      enum:
+        - job
+        - monitor
+        - monitor_group
+      description: Resource types that can be assigned to a webhook.
+
     CreateMonitorResponseDto:
       type: object
       required:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -1242,6 +1242,36 @@ components:
       schema:
         $ref: "#/components/schemas/OwnershipFilter"
 
+    ProjectId:
+      name: project_id
+      in: path
+      required: true
+      description: Unique project identifier.
+      schema:
+        type: string
+        format: uuid
+      example: "60a85db4-78ec-4b78-876a-bc7d9cdadd04"
+
+    ProjectIdQuery:
+      name: project_id
+      in: query
+      required: false
+      description: Filter results to resources belonging to this project.
+      schema:
+        type: string
+        format: uuid
+      example: "60a85db4-78ec-4b78-876a-bc7d9cdadd04"
+
+    DeleteResources:
+      name: delete_resources
+      in: query
+      required: false
+      description: |
+        If true, permanently deletes all resources (jobs, monitors, datasets) assigned to the project. If false, the project is deleted and its resources are unassigned but not deleted.
+      schema:
+        type: boolean
+        default: false
+
   responses:
     InitializeResponse:
       description: Suggestions retrieved successfully

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -3558,6 +3558,28 @@ components:
           description: Timestamp when the resource was assigned in ISO 8601 format with UTC timezone.
           example: "2026-05-18T10:00:00Z"
 
+    AssignWebhookResourceResponseDto:
+      type: object
+      required:
+        - success
+      properties:
+        success:
+          type: boolean
+          description: True if the operation succeeded; false otherwise.
+          example: true
+        message:
+          type: string
+          description: Human-readable result message.
+          example: "Resource assigned to webhook."
+        already_existed:
+          type: boolean
+          description: True if the assignment already existed before this request.
+          default: false
+          example: false
+        mapping:
+          $ref: "#/components/schemas/WebhookResourceMappingResponseDto"
+          description: The created or existing resource mapping.
+
     CreateMonitorResponseDto:
       type: object
       required:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -433,7 +433,7 @@ paths:
                 properties:
                   success:
                     type: boolean
-                    description: Whether the operation succeeded.
+                    description: True if the operation succeeded; false otherwise.
                     example: true
                   message:
                     type: string
@@ -479,7 +479,7 @@ paths:
                 properties:
                   success:
                     type: boolean
-                    description: Whether the operation succeeded.
+                    description: True if the operation succeeded; false otherwise.
                     example: true
                   message:
                     type: string
@@ -2158,7 +2158,7 @@ components:
       properties:
         success:
           type: boolean
-          description: Whether the delete operation succeeded.
+          description: True if the delete operation succeeded; false otherwise.
           example: true
         message:
           type: ["string", "null"]
@@ -2212,7 +2212,7 @@ components:
         completed:
           type: boolean
           default: false
-          description: Whether this step has finished processing.
+          description: True if this step has finished processing; false otherwise.
 
     StatusResponseDto:
       type: object
@@ -2711,7 +2711,7 @@ components:
       properties:
         success:
           type: boolean
-          description: Whether the delete operation succeeded.
+          description: True if the delete operation succeeded; false otherwise.
           example: true
         message:
           type: ["string", "null"]
@@ -2851,7 +2851,7 @@ components:
           example: "Series B funding rounds for SaaS startups"
         enabled:
           type: boolean
-          description: Whether the monitor is currently active.
+          description: True if the monitor is currently active; false otherwise.
           example: true
         schedule:
           type: string
@@ -3028,7 +3028,7 @@ components:
       properties:
         success:
           type: boolean
-          description: Whether the request succeeded.
+          description: True if the request succeeded; false otherwise.
           example: true
         message:
           type: ["string", "null"]

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -2887,6 +2887,31 @@ components:
         - `needs_work`: Query has issues that may reduce result quality. Review `suggestions` for improvements.
         - `critical`: Query is unlikely to produce useful results as written. Address all `issues` before submitting.
 
+    IssueType:
+      type: string
+      enum:
+        - missing_event_type
+        - too_vague
+        - too_specific
+        - wrong_timeframe
+        - static_content
+        - article_request
+        - multiple_event_types
+        - too_short
+        - too_long
+      description: |
+        Category of a query issue identified during validation.
+
+        - `missing_event_type`: Query does not specify a type of event to find.
+        - `too_vague`: Query lacks sufficient focus to return targeted results.
+        - `too_specific`: Query is overly constrained and may return no results.
+        - `wrong_timeframe`: Requested timeframe exceeds the 30-day maximum window or references a historical period outside the supported range.
+        - `static_content`: Query targets static or reference content such as specifications, how-to guides, or historical data rather than events.
+        - `article_request`: Query requests articles or news content rather than describing an event to search for.
+        - `multiple_event_types`: Query mixes unrelated event types; results may be unfocused.
+        - `too_short`: Query is too short to resolve meaningful search intent.
+        - `too_long`: Query is excessively long and may confuse the pipeline.
+
     InitializeRequestDto:
       type: object
       required:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -835,6 +835,43 @@ paths:
         "404":
           $ref: "#/components/responses/NotFoundError"
 
+  /catchAll/resources/{resource_type}/{resource_id}/webhooks:
+    get:
+      tags:
+        - Webhooks
+      summary: List webhooks for resource
+      description: |
+        Returns all webhooks currently assigned to the given resource.
+      operationId: listWebhooksForResource
+      parameters:
+        - $ref: "#/components/parameters/WebhookResourceType"
+        - $ref: "#/components/parameters/WebhookResourceId"
+        - name: is_active
+          in: query
+          required: false
+          schema:
+            type: boolean
+          description: Filter by active status. Omit to return webhooks regardless of status.
+        - $ref: "#/components/parameters/Page"
+        - name: page_size
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+            maximum: 500
+          description: Number of webhooks per page.
+      responses:
+        "200":
+          $ref: "#/components/responses/ListResourceWebhooksResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
   # ── Entities ──────────────────────────────────────────────────────────────
 
   /catchAll/entities:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -3124,6 +3124,16 @@ components:
 
         - `full`: Sends all records in a single request on each trigger.
         - `per_record`: Sends one request per record. For large result sets, this may generate many requests.
+   
+    HttpMethod:
+      type: string
+      enum:
+        - GET
+        - POST
+        - PUT
+        - PATCH
+        - DELETE
+      description: HTTP method used for webhook delivery.
 
     CreateMonitorResponseDto:
       type: object

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -645,6 +645,72 @@ paths:
         "422":
           $ref: "#/components/responses/ValidationError"
 
+  /catchAll/webhooks/{webhook_id}:
+    get:
+      tags:
+        - Webhooks
+      summary: Get webhook
+      description: Returns the full configuration of a single webhook by ID.
+      operationId: getWebhook
+      parameters:
+        - $ref: "#/components/parameters/WebhookId"
+      responses:
+        "200":
+          $ref: "#/components/responses/GetWebhookResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+    patch:
+      tags:
+        - Webhooks
+      summary: Update webhook
+      description: |
+        Updates one or more fields of an existing webhook.
+      operationId: updateWebhook
+      parameters:
+        - $ref: "#/components/parameters/WebhookId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateWebhookRequestDto"
+            example:
+              name: "Layoffs Alert (EU)"
+              is_active: false
+      responses:
+        "200":
+          $ref: "#/components/responses/UpdateWebhookResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+    delete:
+      tags:
+        - Webhooks
+      summary: Delete webhook
+      description: |
+        Permanently deletes a webhook and removes all resource assignments. 
+        
+        Assigned jobs and monitors no longer trigger delivery to this webhook. This operation cannot be undone.
+      operationId: deleteWebhook
+      parameters:
+        - $ref: "#/components/parameters/WebhookId"
+      responses:
+        "204":
+          description: Webhook deleted successfully. No response body.
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
   # ── Entities ──────────────────────────────────────────────────────────────
 
   /catchAll/entities:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -711,6 +711,38 @@ paths:
         "404":
           $ref: "#/components/responses/NotFoundError"
 
+  /catchAll/webhooks/{webhook_id}/test:
+    post:
+      tags:
+        - Webhooks
+      summary: Test webhook delivery
+      description: |
+        Sends a test HTTP request to the webhook URL using the webhook's configured method, headers, and auth. Returns the response from the target endpoint.
+
+        Use this to verify URL reachability and authentication before attaching the webhook to a live job or monitor.
+      operationId: testWebhook
+      parameters:
+        - $ref: "#/components/parameters/WebhookId"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TestWebhookRequestDto"
+            example:
+              payload:
+                test: true
+                message: "CatchAll webhook test"
+      responses:
+        "200":
+          $ref: "#/components/responses/TestWebhookResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
   # ── Entities ──────────────────────────────────────────────────────────────
 
   /catchAll/entities:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -813,6 +813,28 @@ paths:
         "422":
           $ref: "#/components/responses/ValidationError"
 
+  /catchAll/webhooks/{webhook_id}/resources/{resource_type}/{resource_id}:
+    delete:
+      tags:
+        - Webhooks
+      summary: Remove resource from webhook
+      description: |
+        Detaches a resource from this webhook. Completions of the resource no longer trigger delivery to this webhook.
+
+        The webhook and the resource itself are not deleted.
+      operationId: removeWebhookResource
+      parameters:
+        - $ref: "#/components/parameters/WebhookId"
+        - $ref: "#/components/parameters/WebhookResourceType"
+        - $ref: "#/components/parameters/WebhookResourceId"
+      responses:
+        "204":
+          description: Resource removed from webhook. No response body.
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
   # ── Entities ──────────────────────────────────────────────────────────────
 
   /catchAll/entities:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -60,6 +60,18 @@ tags:
         Automate recurring queries with scheduled jobs and webhook
         notifications.
       url: https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/monitors
+  - name: Webhooks
+    description: |
+      Operations to create and manage reusable webhook endpoints.
+
+      A webhook is a named HTTP endpoint that receives a POST notification
+      when a job or monitor completes. Create webhooks once at the organization
+      level and attach them to any number of jobs or monitors via `webhook_ids`.
+      Supports Slack, Microsoft Teams, and generic HTTP targets with configurable
+      delivery modes, authentication, and headers.
+    externalDocs:
+      description: Learn about centralized webhooks and notification setup
+      url: https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/webhooks
   - name: Entities
     description: |
       Operations to create, update, and delete company entities.

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -743,6 +743,76 @@ paths:
         "422":
           $ref: "#/components/responses/ValidationError"
 
+  /catchAll/webhooks/{webhook_id}/resources:
+    post:
+      tags:
+        - Webhooks
+      summary: Assign resource to webhook
+      description: |
+        Attaches a job, monitor, or monitor group to the webhook. When the
+        resource completes, the webhook receives a delivery.
+
+        A single webhook can be assigned to multiple resources. Each resource
+        can have up to 5 webhooks assigned.
+      operationId: assignWebhookResource
+      parameters:
+        - $ref: "#/components/parameters/WebhookId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AssignWebhookResourceRequestDto"
+            example:
+              resource_type: "monitor"
+              resource_id: "3fec5b07-8786-46d7-9486-d43ff67eccd4"
+      responses:
+        "200":
+          $ref: "#/components/responses/AssignWebhookResourceResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+    get:
+      tags:
+        - Webhooks
+      summary: List webhook resources
+      description: |
+        Returns a paginated list of resources currently assigned to this webhook.
+      operationId: listWebhookResources
+      parameters:
+        - $ref: "#/components/parameters/WebhookId"
+        - name: resource_type
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/MappableResourceType"
+          description: Filter assignments by resource type.
+        - $ref: "#/components/parameters/Page"
+        - name: page_size
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+            maximum: 500
+          description: Number of assignments per page.
+      responses:
+        "200":
+          $ref: "#/components/responses/ListWebhookResourcesResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
   # ── Entities ──────────────────────────────────────────────────────────────
 
   /catchAll/entities:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -1507,6 +1507,34 @@ components:
       schema:
         type: boolean
         default: false
+        
+    WebhookId:
+      name: webhook_id
+      in: path
+      required: true
+      description: Unique webhook identifier.
+      schema:
+        type: string
+        format: uuid
+      example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+    WebhookResourceType:
+      name: resource_type
+      in: path
+      required: true
+      description: Type of the resource.
+      schema:
+        $ref: "#/components/schemas/MappableResourceType"
+
+    WebhookResourceId:
+      name: resource_id
+      in: path
+      required: true
+      description: Unique resource identifier.
+      schema:
+        type: string
+        format: uuid
+      example: "3fec5b07-8786-46d7-9486-d43ff67eccd4"
 
   responses:
     InitializeResponse:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -590,6 +590,61 @@ paths:
         "404":
           $ref: "#/components/responses/NotFoundError"
 
+  # ── Webhooks ──────────────────────────────────────────────────────────────
+
+  /catchAll/webhooks:
+    post:
+      tags:
+        - Webhooks
+      summary: Create webhook
+      description: |
+        Creates a new webhook endpoint for the organization.
+      operationId: createWebhook
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateWebhookRequestDto"
+            example:
+              name: "Layoffs Alert"
+              url: "https://hooks.slack.com/services/T000/B000/xxxx"
+              type: "slack"
+              delivery_mode: "full"
+      responses:
+        "201":
+          $ref: "#/components/responses/CreateWebhookResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+    get:
+      tags:
+        - Webhooks
+      summary: List webhooks
+      description: Returns a paginated list of webhooks belonging to the organization.
+      operationId: listWebhooks
+      parameters:
+        - $ref: "#/components/parameters/Page"
+        - name: page_size
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+            maximum: 500
+          description: Number of webhooks per page.
+        - $ref: "#/components/parameters/Search"
+      responses:
+        "200":
+          $ref: "#/components/responses/ListWebhooksResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
   # ── Entities ──────────────────────────────────────────────────────────────
 
   /catchAll/entities:
@@ -2036,7 +2091,7 @@ components:
                 value_type: "integer"
                 value: 200000
                 current_usage: 0
-                
+
     # ── Webhook responses ────────────────────────────────────────────────
 
     CreateWebhookResponse:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -3476,6 +3476,40 @@ components:
             $ref: "#/components/schemas/WebhookResponseDto"
           description: Webhooks on this page.
 
+    TestWebhookRequestDto:
+      type: object
+      properties:
+        payload:
+          type: object
+          description: |
+            Custom payload to send in the test request. If omitted, a synthetic
+            test payload is sent.
+          example:
+            test: true
+            message: "CatchAll webhook test"
+
+    TestWebhookResponseDto:
+      type: object
+      required:
+        - success
+        - message
+      properties:
+        success:
+          type: boolean
+          description: True if the test delivery received a 2xx response; false otherwise.
+          example: true
+        message:
+          type: string
+          description: Human-readable result message.
+          example: "Test delivery succeeded."
+        http_status_code:
+          type: integer
+          description: HTTP status code returned by the webhook endpoint.
+          example: 200
+        response_body:
+          description: Response body returned by the webhook endpoint. Type varies by target.
+          example: "ok"
+
     CreateMonitorResponseDto:
       type: object
       required:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -2551,6 +2551,43 @@ components:
                 created_at: "2026-05-18T10:00:00Z"
                 updated_at: "2026-05-18T10:00:00Z"
 
+    DeliveryHistoryResponse:
+      description: Webhook delivery history retrieved successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/DeliveryHistoryResponseDto"
+          example:
+            resource_type: "monitor"
+            resource_id: "3fec5b07-8786-46d7-9486-d43ff67eccd4"
+            total: 2
+            page: 1
+            page_size: 50
+            total_pages: 1
+            items:
+              - id: 42
+                webhook_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                resource_type: "monitor"
+                resource_id: "3fec5b07-8786-46d7-9486-d43ff67eccd4"
+                additional_info: {}
+                status_code: 200
+                attempt_number: 1
+                timestamp: "2026-05-18T10:00:00Z"
+                delivery_status: "SUCCESS"
+                error_message: null
+                warning_message: null
+              - id: 41
+                webhook_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                resource_type: "monitor"
+                resource_id: "3fec5b07-8786-46d7-9486-d43ff67eccd4"
+                additional_info: {}
+                status_code: 503
+                attempt_number: 1
+                timestamp: "2026-05-17T10:00:00Z"
+                delivery_status: "FAILED"
+                error_message: "Service unavailable"
+                warning_message: null
+
     # ── Project responses ────────────────────────────────────────────────
 
     CreateProjectResponse:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -3580,6 +3580,37 @@ components:
           $ref: "#/components/schemas/WebhookResourceMappingResponseDto"
           description: The created or existing resource mapping.
 
+    ListWebhookResourcesResponseDto:
+      type: object
+      required:
+        - total
+        - page
+        - page_size
+        - total_pages
+        - resources
+      properties:
+        total:
+          type: integer
+          description: Total number of resource mappings for this webhook.
+          example: 2
+        page:
+          type: integer
+          description: Current page number.
+          example: 1
+        page_size:
+          type: integer
+          description: Number of mappings per page.
+          example: 100
+        total_pages:
+          type: integer
+          description: Total number of pages available.
+          example: 1
+        resources:
+          type: array
+          items:
+            $ref: "#/components/schemas/WebhookResourceMappingResponseDto"
+          description: Resource mappings on this page.
+
     CreateMonitorResponseDto:
       type: object
       required:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -1773,6 +1773,123 @@ components:
                 value: 200000
                 current_usage: 0
 
+    # ── Project responses ────────────────────────────────────────────────
+
+    CreateProjectResponseDto:
+      description: Project created successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CreateProjectResponseDto"
+          example:
+            success: true
+            message: "Project created successfully."
+            project_id: "60a85db4-78ec-4b78-876a-bc7d9cdadd04"
+            name: "AI M&A Tracking"
+
+    ProjectResponseDto:
+      description: Project details.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ProjectResponseDto"
+          example:
+            success: true
+            message: "OK"
+            project_id: "60a85db4-78ec-4b78-876a-bc7d9cdadd04"
+            name: "AI M&A Tracking"
+            description: "Tracks AI-related M&A activity for our investment team."
+            resources_count: 4
+            created_at: "2026-05-20T14:31:35Z"
+            updated_at: "2026-05-20T14:31:35Z"
+
+    UpdateProjectResponseDto:
+      description: Project updated successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/UpdateProjectResponseDto"
+          example:
+            success: true
+            message: "Project updated successfully."
+            project_id: "60a85db4-78ec-4b78-876a-bc7d9cdadd04"
+
+    ListProjectsResponse:
+      description: Paginated list of projects.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ProjectListResponseDto"
+          example:
+            total: 2
+            page: 1
+            page_size: 100
+            total_pages: 1
+            projects:
+              - project_id: "60a85db4-78ec-4b78-876a-bc7d9cdadd04"
+                name: "AI M&A Tracking"
+                description: "Tracks AI-related M&A activity."
+                resources_count: 4
+                created_at: "2026-05-20T14:31:35Z"
+                updated_at: "2026-05-20T14:31:35Z"
+
+    ProjectOverviewResponseDto:
+      description: Resource counts for the project, grouped by type and status.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ProjectOverviewResponseDto"
+          example:
+            project_id: "60a85db4-78ec-4b78-876a-bc7d9cdadd04"
+            overview:
+              jobs: {}
+              monitors: {}
+              datasets:
+                total: 2
+              monitor_groups:
+                total: 0
+
+    AddResourceResponseDto:
+      description: Resource added to the project, or already present.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/AddResourceResponseDto"
+          example:
+            success: true
+            message: "Resource added to project."
+            already_exists: false
+
+    ListProjectResourcesResponse:
+      description: Paginated list of resources assigned to the project.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ProjectResourceListResponseDto"
+          example:
+            total: 1
+            page: 1
+            page_size: 100
+            total_pages: 1
+            resources:
+              - resource_type: "job"
+                resource_id: "48421e16-1f50-4048-b62c-d3bc0789d30d"
+                name: "Series B fintech funding rounds"
+                created_at: "2026-05-20T14:31:37Z"
+                metadata: {}
+
+    RemoveResourceResponseDto:
+      description: Resource removed from the project.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/RemoveResourceResponseDto"
+          example:
+            success: true
+            message: "Resource removed from project."
+
+    # ── Common error responses ─────────────────────────────────────────────
+
     BadRequestError:
       description: |
         Bad request - invalid parameters or constraint violations.
@@ -3885,7 +4002,366 @@ components:
           description: |
             The stored attributes for this entity. Present only when attributes exist in the database. 
             
-            The field name matches the value of `type` — for example, `"company"` type entities have a `company` field.
+            The field name matches the value of `type` — for example, `"company"` type entities have a `company`  field.
+
+# ── Project schemas ───────────────────────────────────────────────────
+
+    ProjectResourceType:
+      type: string
+      enum:
+        - job
+        - monitor
+        - dataset
+        - monitor_group
+      description: |
+        Resource type for project association.
+
+        - `job`: A processing job created via `POST /catchAll/submit`.
+        - `monitor`: A scheduled monitor created via `POST /catchAll/monitors/create`.
+        - `dataset`: An entity dataset created via `POST /catchAll/datasets`.
+        - `monitor_group`: A group of monitors (reserved for future use).
+
+    CreateProjectRequestDto:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: Name for the project.
+          example: "AI M&A Tracking"
+        description:
+          type: string
+          description: Optional description.
+          example: "Tracks AI-related M&A activity for our investment team."
+
+    UpdateProjectRequestDto:
+      type: object
+      description: Updates one or more fields of an existing project. At least one field must be provided.
+      properties:
+        name:
+          type: string
+          minLength: 1
+          description: New name for the project.
+          example: "AI M&A Tracking (Q2)"
+        description:
+          type: string
+          description: New description for the project.
+          example: "Updated scope to include private equity."
+
+    AddResourceRequestDto:
+      type: object
+      required:
+        - resource_type
+        - resource_id
+      properties:
+        resource_type:
+          $ref: "#/components/schemas/ProjectResourceType"
+        resource_id:
+          type: string
+          format: uuid
+          description: ID of the resource to add.
+          example: "48421e16-1f50-4048-b62c-d3bc0789d30d"
+
+    CreateProjectResponseDto:
+      type: object
+      required:
+        - success
+        - message
+        - project_id
+        - name
+      properties:
+        success:
+          type: boolean
+          description: True if the operation succeeded; false otherwise.
+          example: true
+        message:
+          type: string
+          description: Human-readable result message.
+          example: "Project created successfully."
+        project_id:
+          type: string
+          format: uuid
+          description: Project identifier.
+          example: "60a85db4-78ec-4b78-876a-bc7d9cdadd04"
+        name:
+          type: string
+          description: Name of the created project.
+          example: "AI M&A Tracking"
+
+    ProjectResponseDto:
+      type: object
+      required:
+        - success
+        - message
+        - project_id
+        - name
+      properties:
+        success:
+          type: boolean
+          description: True if the operation succeeded; false otherwise.
+          example: true
+        message:
+          type: string
+          description: Human-readable result message.
+          example: "OK"
+        project_id:
+          type: string
+          format: uuid
+          description: Project identifier.
+          example: "60a85db4-78ec-4b78-876a-bc7d9cdadd04"
+        name:
+          type: string
+          description: Project name.
+          example: "AI M&A Tracking"
+        description:
+          type: ["string", "null"]
+          description: Project description.
+          example: "Tracks AI-related M&A activity for our investment team."
+        resources_count:
+          type: integer
+          description: Number of resources assigned to this project.
+          example: 4
+          default: 0
+        created_at:
+          type: string
+          format: date-time
+          description: Project creation timestamp.
+          example: "2026-05-20T14:31:35Z"
+        updated_at:
+          type: string
+          format: date-time
+          description: Timestamp of the last update.
+          example: "2026-05-20T14:31:35Z"
+
+    UpdateProjectResponseDto:
+      type: object
+      required:
+        - success
+        - message
+        - project_id
+      properties:
+        success:
+          type: boolean
+          description: True if the operation succeeded; false otherwise.
+          example: true
+        message:
+          type: string
+          description: Human-readable result message.
+          example: "Project updated successfully."
+        project_id:
+          type: string
+          format: uuid
+          description: Project identifier.
+          example: "60a85db4-78ec-4b78-876a-bc7d9cdadd04"
+
+    ProjectSummaryDto:
+      type: object
+      description: Abbreviated project object returned in list responses.
+      required:
+        - project_id
+        - name
+      properties:
+        project_id:
+          type: string
+          format: uuid
+          description: Project identifier.
+          example: "60a85db4-78ec-4b78-876a-bc7d9cdadd04"
+        name:
+          type: string
+          description: Project name.
+          example: "AI M&A Tracking"
+        description:
+          type: ["string", "null"]
+          description: Project description.
+          example: "Tracks AI-related M&A activity for our investment team."
+        resources_count:
+          type: integer
+          description: Number of resources assigned to this project.
+          example: 4
+          default: 0
+        created_at:
+          type: string
+          format: date-time
+          description: Project creation timestamp.
+          example: "2026-05-20T14:31:35Z"
+        updated_at:
+          type: string
+          format: date-time
+          description: Timestamp of the last update.
+          example: "2026-05-20T14:31:35Z"
+
+    ProjectListResponseDto:
+      type: object
+      required:
+        - total
+        - page
+        - page_size
+        - total_pages
+        - projects
+      properties:
+        total:
+          type: integer
+          description: Total number of projects matching the filter criteria.
+          example: 2
+        page:
+          type: integer
+          description: Current page number.
+          example: 1
+        page_size:
+          type: integer
+          description: Number of projects per page.
+          example: 100
+        total_pages:
+          type: integer
+          description: Total number of pages.
+          example: 1
+        projects:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProjectSummaryDto"
+          description: Projects on this page.
+
+    ProjectOverviewCountsDto:
+      type: object
+      description: |
+        Status breakdown for a single resource type.
+
+        For `jobs` and `monitors`: keys are status values (for example,
+        `completed`, `failed`) and values are integer counts. Returns `{}`
+        when no resources of that type are assigned.
+
+        For `datasets` and `monitor_groups`: contains a single `total` field.
+      additionalProperties: true
+
+    ProjectOverviewResponseDto:
+      type: object
+      required:
+        - project_id
+        - overview
+      properties:
+        project_id:
+          type: string
+          format: uuid
+          description: Project identifier.
+          example: "60a85db4-78ec-4b78-876a-bc7d9cdadd04"
+        overview:
+          type: object
+          description: Resource counts grouped by type.
+          required:
+            - jobs
+            - monitors
+            - datasets
+            - monitor_groups
+          properties:
+            jobs:
+              $ref: "#/components/schemas/ProjectOverviewCountsDto"
+            monitors:
+              $ref: "#/components/schemas/ProjectOverviewCountsDto"
+            datasets:
+              $ref: "#/components/schemas/ProjectOverviewCountsDto"
+            monitor_groups:
+              $ref: "#/components/schemas/ProjectOverviewCountsDto"
+
+    ProjectResourceDto:
+      type: object
+      description: A resource assigned to a project.
+      required:
+        - resource_type
+        - resource_id
+      properties:
+        resource_type:
+          $ref: "#/components/schemas/ProjectResourceType"
+        resource_id:
+          type: string
+          format: uuid
+          description: Resource identifier.
+          example: "48421e16-1f50-4048-b62c-d3bc0789d30d"
+        name:
+          type: string
+          description: |
+            Resource display name. For jobs, this is the original query
+            string. For monitors and datasets, this is the resource name.
+          example: "Series B fintech funding rounds"
+        created_at:
+          type: string
+          format: date-time
+          description: Resource creation timestamp.
+          example: "2026-05-20T14:31:37Z"
+        metadata:
+          type: object
+          description: Additional resource-specific metadata. Reserved for future use.
+          additionalProperties: true
+          example: {}
+
+    ProjectResourceListResponseDto:
+      type: object
+      required:
+        - total
+        - page
+        - page_size
+        - total_pages
+        - resources
+      properties:
+        total:
+          type: integer
+          description: Total number of resources assigned to the project.
+          example: 1
+        page:
+          type: integer
+          description: Current page number.
+          example: 1
+        page_size:
+          type: integer
+          description: Number of resources per page.
+          example: 100
+        total_pages:
+          type: integer
+          description: Total number of pages.
+          example: 1
+        resources:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProjectResourceDto"
+          description: Resources on this page.
+
+    AddResourceResponseDto:
+      type: object
+      required:
+        - success
+        - message
+      properties:
+        success:
+          type: boolean
+          description: True if the operation succeeded; false otherwise.
+          example: true
+        message:
+          type: string
+          description: Human-readable result message.
+          example: "Resource added to project."
+        already_exists:
+          type: boolean
+          description: |
+            True if the resource was already assigned to this project; false
+            otherwise. The operation is idempotent — returns `200` in either
+            case.
+          example: false
+
+    RemoveResourceResponseDto:
+      type: object
+      required:
+        - success
+        - message
+      properties:
+        success:
+          type: boolean
+          description: True if the operation succeeded; false otherwise.
+          example: true
+        message:
+          type: string
+          description: Human-readable result message.
+          example: "Resource removed from project."
 
     GetPlanLimitsResponseDto:
       type: object

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -1818,6 +1818,20 @@ components:
       example: "3fec5b07-8786-46d7-9486-d43ff67eccd4"
 
   responses:
+    ValidateQueryResponse:
+      description: Query validation result.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ValidateQueryResponseDto"
+          example:
+            status: "good"
+            title: "Specific event type clear"
+            description: "Clear event type and focus; no timeframe needed for a default recent search."
+            issues: []
+            suggestions: []
+            confidence: 0.98
+            
     InitializeResponse:
       description: Suggestions retrieved successfully
       content:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -793,7 +793,6 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/MappableResourceType"
-          description: Filter assignments by resource type.
         - $ref: "#/components/parameters/Page"
         - name: page_size
           in: query
@@ -1805,7 +1804,6 @@ components:
       name: resource_type
       in: path
       required: true
-      description: Type of the resource.
       schema:
         $ref: "#/components/schemas/MappableResourceType"
 
@@ -2875,6 +2873,19 @@ components:
               enum: ["low", "medium", "high", null]
               description: Confidence level for the domain URL resolution.
               example: "high"
+
+    QueryStatus:
+      type: string
+      enum:
+        - good
+        - needs_work
+        - critical
+      description: |
+        Quality level assigned to a query by the validation endpoint.
+
+        - `good`: Query is well-formed and likely to produce relevant results.
+        - `needs_work`: Query has issues that may reduce result quality. Review `suggestions` for improvements.
+        - `critical`: Query is unlikely to produce useful results as written. Address all `issues` before submitting.
 
     InitializeRequestDto:
       type: object

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -80,6 +80,16 @@ tags:
     externalDocs:
       description: Learn about datasets and Company Watchlist
       url: https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/company-search
+  - name: Projects
+    description: |
+      Operations to create, organize, and manage projects.
+
+      A project is a named container for jobs, monitors, and datasets. Group
+      related resources by use case, team, or client, and share them with
+      teammates. Resources can be assigned at creation time or post-hoc.
+    externalDocs:
+      description: Learn about projects and resource organization
+      url: https://www.newscatcherapi.com/docs/web-search-api/guides-and-concepts/projects
   - name: Meta
     description: Operations to check API health and version.
 

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -3510,6 +3510,21 @@ components:
           description: Response body returned by the webhook endpoint. Type varies by target.
           example: "ok"
 
+    AssignWebhookResourceRequestDto:
+      type: object
+      required:
+        - resource_type
+        - resource_id
+      properties:
+        resource_type:
+          $ref: "#/components/schemas/MappableResourceType"
+          description: Type of resource to assign.
+        resource_id:
+          type: string
+          format: uuid
+          description: ID of the resource to assign.
+          example: "3fec5b07-8786-46d7-9486-d43ff67eccd4"
+
     CreateMonitorResponseDto:
       type: object
       required:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -2943,6 +2943,45 @@ components:
       example:
         query: "Series B funding rounds for SaaS startups"
 
+    ValidateQueryResponseDto:
+      type: object
+      description: Query quality assessment returned by the validate endpoint.
+      required:
+        - status
+        - title
+        - confidence
+      properties:
+        status:
+          $ref: "#/components/schemas/QueryStatus"
+          description: Overall quality level of the query.
+        title:
+          type: string
+          description: Short headline summarising the assessment.
+          example: "Specific event type clear"
+        description:
+          type: string
+          description: Plain-language explanation of the assessment result.
+          example: "Clear event type and focus; no timeframe needed for a default recent search."
+        issues:
+          type: array
+          items:
+            $ref: "#/components/schemas/IssueType"
+          description: Issues identified in the query. Empty when `status` is `good`.
+          example: []
+        suggestions:
+          type: array
+          items:
+            $ref: "#/components/schemas/Suggestion"
+          description: |
+            Actionable recommendations for each identified issue. Empty when `status` is `good`. Each suggestion corresponds to one entry in `issues`.
+          example: []
+        confidence:
+          type: number
+          minimum: 0
+          maximum: 1
+          description: Confidence score for this assessment.
+          example: 0.98
+
     InitializeRequestDto:
       type: object
       required:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -1131,6 +1131,226 @@ paths:
         "422":
           $ref: "#/components/responses/ValidationError"
 
+# ── Projects ──────────────────────────────────────────────────────────
+
+  /catchAll/projects:
+    post:
+      tags:
+        - Projects
+      summary: Create project
+      description: Creates a new project.
+      operationId: createProject
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateProjectRequestDto"
+            example:
+              name: "AI M&A Tracking"
+              description: "Tracks AI-related M&A activity for our investment team."
+      responses:
+        "201":
+          $ref: "#/components/responses/CreateProjectResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+    get:
+      tags:
+        - Projects
+      summary: List projects
+      description: Returns all projects visible to the authenticated user.
+      operationId: listProjects
+      parameters:
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/PageSize"
+        - name: search
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by project name (case-insensitive substring match).
+          example: "M&A"
+        - $ref: "#/components/parameters/Ownership"
+      responses:
+        "200":
+          $ref: "#/components/responses/ListProjectsResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+  /catchAll/projects/{project_id}:
+    get:
+      tags:
+        - Projects
+      summary: Get project
+      description: Returns a single project by ID.
+      operationId: getProject
+      parameters:
+        - $ref: "#/components/parameters/ProjectId"
+      responses:
+        "200":
+          $ref: "#/components/responses/ProjectResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
+    patch:
+      tags:
+        - Projects
+      summary: Update project
+      description: Updates the name or description of an existing project.
+      operationId: updateProject
+      parameters:
+        - $ref: "#/components/parameters/ProjectId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateProjectRequestDto"
+            example:
+              name: "AI M&A Tracking (Q2 2026)"
+      responses:
+        "200":
+          $ref: "#/components/responses/UpdateProjectResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+    delete:
+      tags:
+        - Projects
+      summary: Delete project
+      description: |
+        Deletes a project. By default, assigned resources are unassigned but not deleted. 
+      operationId: deleteProject
+      parameters:
+        - $ref: "#/components/parameters/ProjectId"
+        - $ref: "#/components/parameters/DeleteResources"
+      responses:
+        "204":
+          description: Project deleted successfully. No response body.
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
+  /catchAll/projects/{project_id}/overview:
+    get:
+      tags:
+        - Projects
+      summary: Get project overview
+      description: |
+        Returns resource counts for a project, grouped by type and status.
+
+        For `jobs` and `monitors`, counts are broken down by status (for example, `completed`, `failed`). For `datasets` and `monitor_groups`, only a `total` count is returned.
+      operationId: getProjectOverview
+      parameters:
+        - $ref: "#/components/parameters/ProjectId"
+      responses:
+        "200":
+          $ref: "#/components/responses/ProjectOverviewResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
+  /catchAll/projects/{project_id}/resources:
+    post:
+      tags:
+        - Projects
+      summary: Add resource to project
+      description: |
+        Assigns an existing resource to a project.
+
+        The operation is idempotent — if the resource is already assigned, the response is `200` with `already_exists: true`.
+      operationId: addResourceToProject
+      parameters:
+        - $ref: "#/components/parameters/ProjectId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AddResourceRequestDto"
+            example:
+              resource_type: "job"
+              resource_id: "48421e16-1f50-4048-b62c-d3bc0789d30d"
+      responses:
+        "200":
+          $ref: "#/components/responses/AddResourceResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+    get:
+      tags:
+        - Projects
+      summary: List project resources
+      description: Returns all resources assigned to a project, with optional filtering by type.
+      operationId: listProjectResources
+      parameters:
+        - $ref: "#/components/parameters/ProjectId"
+        - name: resource_type
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/ProjectResourceType"
+        - $ref: "#/components/parameters/Page"
+        - $ref: "#/components/parameters/PageSize"
+      responses:
+        "200":
+          $ref: "#/components/responses/ListProjectResourcesResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/ValidationError"
+
+  /catchAll/projects/{project_id}/resources/{resource_type}/{resource_id}:
+    delete:
+      tags:
+        - Projects
+      summary: Remove resource from project
+      description: |
+        Removes a resource from a project. The resource itself is not
+        deleted — it becomes unassigned and continues to exist.
+      operationId: removeResourceFromProject
+      parameters:
+        - $ref: "#/components/parameters/ProjectId"
+        - name: resource_type
+          in: path
+          required: true
+          schema:
+            $ref: "#/components/schemas/ProjectResourceType"
+        - name: resource_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: ID of the resource to remove.
+          example: "48421e16-1f50-4048-b62c-d3bc0789d30d"
+      responses:
+        "200":
+          $ref: "#/components/responses/RemoveResourceResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+
   # ── Meta ──────────────────────────────────────────────────────────────
 
   /health:
@@ -1775,7 +1995,7 @@ components:
 
     # ── Project responses ────────────────────────────────────────────────
 
-    CreateProjectResponseDto:
+    CreateProjectResponse:
       description: Project created successfully.
       content:
         application/json:
@@ -1787,7 +2007,7 @@ components:
             project_id: "60a85db4-78ec-4b78-876a-bc7d9cdadd04"
             name: "AI M&A Tracking"
 
-    ProjectResponseDto:
+    ProjectResponse:
       description: Project details.
       content:
         application/json:
@@ -1803,7 +2023,7 @@ components:
             created_at: "2026-05-20T14:31:35Z"
             updated_at: "2026-05-20T14:31:35Z"
 
-    UpdateProjectResponseDto:
+    UpdateProjectResponse:
       description: Project updated successfully.
       content:
         application/json:
@@ -1833,7 +2053,7 @@ components:
                 created_at: "2026-05-20T14:31:35Z"
                 updated_at: "2026-05-20T14:31:35Z"
 
-    ProjectOverviewResponseDto:
+    ProjectOverviewResponse:
       description: Resource counts for the project, grouped by type and status.
       content:
         application/json:
@@ -1849,7 +2069,7 @@ components:
               monitor_groups:
                 total: 0
 
-    AddResourceResponseDto:
+    AddResourceResponse:
       description: Resource added to the project, or already present.
       content:
         application/json:
@@ -1878,7 +2098,7 @@ components:
                 created_at: "2026-05-20T14:31:37Z"
                 metadata: {}
 
-    RemoveResourceResponseDto:
+    RemoveResourceResponse:
       description: Resource removed from the project.
       content:
         application/json:
@@ -4015,12 +4235,6 @@ components:
         - monitor_group
       description: |
         Resource type for project association.
-
-        - `job`: A processing job created via `POST /catchAll/submit`.
-        - `monitor`: A scheduled monitor created via `POST /catchAll/monitors/create`.
-        - `dataset`: An entity dataset created via `POST /catchAll/datasets`.
-        - `monitor_group`: A group of monitors (reserved for future use).
-
     CreateProjectRequestDto:
       type: object
       required:
@@ -4227,12 +4441,6 @@ components:
       type: object
       description: |
         Status breakdown for a single resource type.
-
-        For `jobs` and `monitors`: keys are status values (for example,
-        `completed`, `failed`) and values are integer counts. Returns `{}`
-        when no resources of that type are assigned.
-
-        For `datasets` and `monitor_groups`: contains a single `total` field.
       additionalProperties: true
 
     ProjectOverviewResponseDto:
@@ -4291,7 +4499,7 @@ components:
           example: "2026-05-20T14:31:37Z"
         metadata:
           type: object
-          description: Additional resource-specific metadata. Reserved for future use.
+          description: Additional resource-specific metadata.
           additionalProperties: true
           example: {}
 

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -3201,6 +3201,77 @@ components:
           description: Basic auth password.
           example: "pass"
 
+    WebhookResponseDto:
+      type: object
+      required:
+        - id
+        - name
+        - url
+        - type
+        - delivery_mode
+        - method
+        - is_active
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Webhook identifier.
+          example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        name:
+          type: string
+          description: Human-readable label for this webhook.
+          example: "Layoffs Alert"
+        url:
+          type: string
+          format: uri
+          description: Destination URL that receives the payload.
+          example: "https://hooks.slack.com/services/T000/B000/xxxx"
+        type:
+          $ref: "#/components/schemas/WebhookType"
+        delivery_mode:
+          $ref: "#/components/schemas/DeliveryMode"
+        method:
+          $ref: "#/components/schemas/HttpMethod"
+        headers:
+          type: object
+          additionalProperties:
+            type: string
+          description: Custom HTTP headers forwarded with each delivery.
+          example:
+            Authorization: "Bearer token123"
+        params:
+          type: object
+          additionalProperties:
+            type: string
+          description: Query parameters appended to the webhook URL.
+          example: {}
+        formatter_config:
+          type: ["object", "null"]
+          description: Custom payload transformation configuration. Used only when `type` is `custom`.
+          example: null
+        is_active:
+          type: boolean
+          description: True if the webhook is active; false otherwise.
+          example: true
+        organization_id:
+          type: string
+          description: Organization that owns this webhook.
+          example: "org-uuid-here"
+        created_by_user_id:
+          type: string
+          description: ID of the user who created this webhook.
+          example: "user-uuid-here"
+        created_at:
+          type: string
+          format: date-time
+          description: Webhook creation timestamp in ISO 8601 format with UTC timezone.
+          example: "2026-05-18T10:00:00Z"
+        updated_at:
+          type: string
+          format: date-time
+          description: Timestamp of the last update in ISO 8601 format with UTC timezone.
+          example: "2026-05-18T10:00:00Z"
+
     CreateMonitorResponseDto:
       type: object
       required:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -2931,6 +2931,18 @@ components:
           description: Revised query demonstrating the suggested improvement.
           example: "Series A fundraising for AI startups in healthcare"
 
+    ValidateQueryRequestDto:
+      type: object
+      required:
+        - query
+      properties:
+        query:
+          type: string
+          description: Plain text query to validate.
+          example: "Series B funding rounds for SaaS startups"
+      example:
+        query: "Series B funding rounds for SaaS startups"
+
     InitializeRequestDto:
       type: object
       required:
@@ -2941,8 +2953,7 @@ components:
         context:
           $ref: "#/components/schemas/Context"
       description:
-        Request to get validator, enrichment, and date range suggestions for a
-        query.
+        Request to get validator, enrichment, and date range suggestions for a query.
 
     InitializeResponseDto:
       type: object

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -3393,6 +3393,58 @@ components:
           $ref: "#/components/schemas/WebhookResponseDto"
           description: The updated webhook object.
 
+    UpdateWebhookRequestDto:
+      type: object
+      description: All fields are optional. Only supplied fields are updated.
+      properties:
+        name:
+          type: string
+          description: Updated webhook name.
+          example: "Layoffs Alert (EU)"
+        url:
+          type: string
+          format: uri
+          description: Updated destination URL. Must use HTTPS. Type-specific URL rules apply.
+          example: "https://hooks.slack.com/services/T000/B111/yyyy"
+        type:
+          $ref: "#/components/schemas/WebhookType"
+        delivery_mode:
+          $ref: "#/components/schemas/DeliveryMode"
+        method:
+          $ref: "#/components/schemas/HttpMethod"
+        headers:
+          type: object
+          additionalProperties:
+            type: string
+          description: Updated HTTP headers. Replaces existing headers entirely.
+          example:
+            Authorization: "Bearer new-token"
+        params:
+          type: object
+          additionalProperties:
+            type: string
+          description: Updated query parameters. Replaces existing params entirely.
+          example: {}
+        auth:
+          oneOf:
+            - $ref: "#/components/schemas/BearerAuthDto"
+            - $ref: "#/components/schemas/ApiKeyAuthDto"
+            - $ref: "#/components/schemas/BasicAuthDto"
+          discriminator:
+            propertyName: type
+            mapping:
+              bearer: "#/components/schemas/BearerAuthDto"
+              api_key: "#/components/schemas/ApiKeyAuthDto"
+              basic: "#/components/schemas/BasicAuthDto"
+          description: Updated authentication configuration. Replaces existing auth entirely.
+        formatter_config:
+          type: ["object", "null"]
+          description: Updated formatter configuration.
+        is_active:
+          type: boolean
+          description: Set to `false` to disable delivery without deleting the webhook.
+          example: false
+
     CreateMonitorResponseDto:
       type: object
       required:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -2994,6 +2994,15 @@ components:
           description: |
             Project to assign this job to. The job appears in the project's resource list immediately after submission.
           example: "60a85db4-78ec-4b78-876a-bc7d9cdadd04"
+        webhook_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          description: |
+            IDs of webhooks to notify when the job completes. Maximum 5 per job.
+          example:
+            - "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 
     SubmitResponseDto:
       type: object

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -3846,6 +3846,47 @@ components:
           description: Non-fatal warning, such as payload truncation notices. Null when no warnings occurred.
           example: null
 
+    DeliveryHistoryResponseDto:
+      type: object
+      required:
+        - resource_type
+        - resource_id
+        - total
+        - page
+        - page_size
+        - total_pages
+        - items
+      properties:
+        resource_type:
+          $ref: "#/components/schemas/MappableResourceType"
+          description: Type of the queried resource.
+        resource_id:
+          type: string
+          format: uuid
+          description: Identifier of the queried resource.
+          example: "3fec5b07-8786-46d7-9486-d43ff67eccd4"
+        total:
+          type: integer
+          description: Total number of delivery records for this resource.
+          example: 42
+        page:
+          type: integer
+          description: Current page number.
+          example: 1
+        page_size:
+          type: integer
+          description: Number of records per page.
+          example: 50
+        total_pages:
+          type: integer
+          description: Total number of pages available.
+          example: 1
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/DeliveryHistoryItemDto"
+          description: Delivery records on this page, ordered by timestamp descending.
+
     BearerAuthDto:
       type: object
       required:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -3525,6 +3525,39 @@ components:
           description: ID of the resource to assign.
           example: "3fec5b07-8786-46d7-9486-d43ff67eccd4"
 
+    WebhookResourceMappingResponseDto:
+      type: object
+      required:
+        - id
+        - webhook_id
+        - resource_type
+        - resource_id
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Mapping identifier.
+          example: "f1e2d3c4-b5a6-7890-abcd-ef1234567890"
+        webhook_id:
+          type: string
+          format: uuid
+          description: Webhook identifier.
+          example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        resource_type:
+          type: string
+          description: Type of the assigned resource.
+          example: "monitor"
+        resource_id:
+          type: string
+          format: uuid
+          description: Identifier of the assigned resource.
+          example: "3fec5b07-8786-46d7-9486-d43ff67eccd4"
+        assigned_at:
+          type: string
+          format: date-time
+          description: Timestamp when the resource was assigned in ISO 8601 format with UTC timezone.
+          example: "2026-05-18T10:00:00Z"
+
     CreateMonitorResponseDto:
       type: object
       required:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NewsCatcher CatchAll API
-  version: 1.5.3
+  version: 1.6.0
   description: |
     CatchAll is a web search API that generates unique datasets that don't exist anywhere else on the web. Built on NewsCatcher's proprietary real-world event index, it delivers state-of-the-art recall—finding all relevant events, not just top results.
 

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -1270,11 +1270,9 @@ paths:
     post:
       tags:
         - Projects
-      summary: Add resource to project
+      summary: Add resources to project
       description: |
-        Assigns an existing resource to a project.
-
-        The operation is idempotent — if the resource is already assigned, the response is `200` with `already_exists: true`.
+        Assigns one or more existing resources to a project in a single request.
       operationId: addResourceToProject
       parameters:
         - $ref: "#/components/parameters/ProjectId"
@@ -1285,17 +1283,20 @@ paths:
             schema:
               $ref: "#/components/schemas/AddResourceRequestDto"
             example:
-              resource_type: "job"
-              resource_id: "48421e16-1f50-4048-b62c-d3bc0789d30d"
+              resources:
+                - resource_type: "job"
+                  resource_id: "48421e16-1f50-4048-b62c-d3bc0789d30d"
       responses:
         "200":
           $ref: "#/components/responses/AddResourceResponse"
+        "201":
+          $ref: "#/components/responses/AddResourceResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestError"
         "403":
           $ref: "#/components/responses/ForbiddenError"
         "404":
           $ref: "#/components/responses/NotFoundError"
-        "422":
-          $ref: "#/components/responses/ValidationError"
 
     get:
       tags:
@@ -2073,15 +2074,21 @@ components:
                 total: 0
 
     AddResourceResponse:
-      description: Resource added to the project, or already present.
+      description: |
+        One or more resources added to the project (`201`), or all were already present (`200`).
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/AddResourceResponseDto"
           example:
             success: true
-            message: "Resource added to project."
-            already_exists: false
+            message: "Resources added to project."
+            results:
+              - resource_type: "job"
+                resource_id: "48421e16-1f50-4048-b62c-d3bc0789d30d"
+                success: true
+                message: "Resource added to project."
+                already_exists: false
 
     ListProjectResourcesResponse:
       description: Paginated list of resources assigned to the project.
@@ -4282,6 +4289,18 @@ components:
     AddResourceRequestDto:
       type: object
       required:
+        - resources
+      properties:
+        resources:
+          type: array
+          minItems: 1
+          description: Resources to assign to the project.
+          items:
+            $ref: "#/components/schemas/ResourceItemDto"
+
+    ResourceItemDto:
+      type: object
+      required:
         - resource_type
         - resource_id
       properties:
@@ -4554,21 +4573,51 @@ components:
       required:
         - success
         - message
+        - results
       properties:
         success:
           type: boolean
-          description: True if the operation succeeded; false otherwise.
+          description: True if the overall operation succeeded.
           example: true
         message:
           type: string
-          description: Human-readable result message.
+          description: Top-level result message.
+          example: "Resources added to project."
+        results:
+          type: array
+          description: Per-resource outcome, one entry per submitted resource.
+          items:
+            $ref: "#/components/schemas/ResourceResultDto"
+
+    ResourceResultDto:
+      type: object
+      required:
+        - resource_type
+        - resource_id
+        - success
+        - message
+      properties:
+        resource_type:
+          type: string
+          description: Type of the resource.
+          example: "job"
+        resource_id:
+          type: string
+          format: uuid
+          description: Resource identifier.
+          example: "48421e16-1f50-4048-b62c-d3bc0789d30d"
+        success:
+          type: boolean
+          description: True if this resource was processed successfully.
+          example: true
+        message:
+          type: string
+          description: Per-resource result message.
           example: "Resource added to project."
         already_exists:
           type: boolean
-          description: |
-            True if the resource was already assigned to this project; false
-            otherwise. The operation is idempotent — returns `200` in either
-            case.
+          description: True if the resource is already assigned to this project.
+          default: false
           example: false
 
     RemoveResourceResponseDto:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -2036,6 +2036,199 @@ components:
                 value_type: "integer"
                 value: 200000
                 current_usage: 0
+                
+    # ── Webhook responses ────────────────────────────────────────────────
+
+    CreateWebhookResponse:
+      description: Webhook created successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CreateWebhookResponseDto"
+          example:
+            success: true
+            message: "Webhook created successfully."
+            webhook:
+              id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              name: "Layoffs Alert"
+              url: "https://hooks.slack.com/services/T000/B000/xxxx"
+              type: "slack"
+              delivery_mode: "full"
+              method: "POST"
+              headers: {}
+              params: {}
+              formatter_config: null
+              is_active: true
+              organization_id: "org-uuid-here"
+              created_by_user_id: "user-uuid-here"
+              created_at: "2026-05-18T10:00:00Z"
+              updated_at: "2026-05-18T10:00:00Z"
+
+    GetWebhookResponse:
+      description: Webhook retrieved successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/GetWebhookResponseDto"
+          example:
+            success: true
+            message: "Webhook retrieved successfully."
+            webhook:
+              id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              name: "Layoffs Alert"
+              url: "https://hooks.slack.com/services/T000/B000/xxxx"
+              type: "slack"
+              delivery_mode: "full"
+              method: "POST"
+              headers: {}
+              params: {}
+              formatter_config: null
+              is_active: true
+              organization_id: "org-uuid-here"
+              created_by_user_id: "user-uuid-here"
+              created_at: "2026-05-18T10:00:00Z"
+              updated_at: "2026-05-18T10:00:00Z"
+
+    UpdateWebhookResponse:
+      description: Webhook updated successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/UpdateWebhookResponseDto"
+          example:
+            success: true
+            message: "Webhook updated successfully."
+            webhook:
+              id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              name: "Layoffs Alert (EU)"
+              url: "https://hooks.slack.com/services/T000/B111/yyyy"
+              type: "slack"
+              delivery_mode: "full"
+              method: "POST"
+              headers: {}
+              params: {}
+              formatter_config: null
+              is_active: true
+              organization_id: "org-uuid-here"
+              created_by_user_id: "user-uuid-here"
+              created_at: "2026-05-18T10:00:00Z"
+              updated_at: "2026-05-19T08:30:00Z"
+
+    ListWebhooksResponse:
+      description: Webhooks retrieved successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ListWebhooksResponseDto"
+          example:
+            total: 2
+            page: 1
+            page_size: 100
+            total_pages: 1
+            webhooks:
+              - id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                name: "Layoffs Alert"
+                url: "https://hooks.slack.com/services/T000/B000/xxxx"
+                type: "slack"
+                delivery_mode: "full"
+                method: "POST"
+                headers: {}
+                params: {}
+                formatter_config: null
+                is_active: true
+                organization_id: "org-uuid-here"
+                created_by_user_id: "user-uuid-here"
+                created_at: "2026-05-18T10:00:00Z"
+                updated_at: "2026-05-18T10:00:00Z"
+              - id: "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+                name: "M&A Tracker"
+                url: "https://my-service.example.com/catchall-hook"
+                type: "generic"
+                delivery_mode: "per_record"
+                method: "POST"
+                headers:
+                  Authorization: "Bearer token123"
+                params: {}
+                formatter_config: null
+                is_active: true
+                organization_id: "org-uuid-here"
+                created_by_user_id: "user-uuid-here"
+                created_at: "2026-05-19T09:00:00Z"
+                updated_at: "2026-05-19T09:00:00Z"
+
+    TestWebhookResponse:
+      description: Test delivery attempted. Check `success` and `http_status_code` for the outcome.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/TestWebhookResponseDto"
+          example:
+            success: true
+            message: "Test delivery succeeded."
+            http_status_code: 200
+            response_body: "ok"
+
+    AssignWebhookResourceResponse:
+      description: Resource assigned to webhook.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/AssignWebhookResourceResponseDto"
+          example:
+            success: true
+            message: "Resource assigned to webhook."
+            already_existed: false
+            mapping:
+              id: "f1e2d3c4-b5a6-7890-abcd-ef1234567890"
+              webhook_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              resource_type: "monitor"
+              resource_id: "3fec5b07-8786-46d7-9486-d43ff67eccd4"
+              assigned_at: "2026-05-18T10:00:00Z"
+
+    ListWebhookResourcesResponse:
+      description: Webhook resource assignments retrieved successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ListWebhookResourcesResponseDto"
+          example:
+            total: 1
+            page: 1
+            page_size: 100
+            total_pages: 1
+            resources:
+              - id: "f1e2d3c4-b5a6-7890-abcd-ef1234567890"
+                webhook_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                resource_type: "monitor"
+                resource_id: "3fec5b07-8786-46d7-9486-d43ff67eccd4"
+                assigned_at: "2026-05-18T10:00:00Z"
+
+    ListResourceWebhooksResponse:
+      description: Webhooks for resource retrieved successfully.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ListWebhooksResponseDto"
+          example:
+            total: 1
+            page: 1
+            page_size: 100
+            total_pages: 1
+            webhooks:
+              - id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                name: "Layoffs Alert"
+                url: "https://hooks.slack.com/services/T000/B000/xxxx"
+                type: "slack"
+                delivery_mode: "full"
+                method: "POST"
+                headers: {}
+                params: {}
+                formatter_config: null
+                is_active: true
+                organization_id: "org-uuid-here"
+                created_by_user_id: "user-uuid-here"
+                created_at: "2026-05-18T10:00:00Z"
+                updated_at: "2026-05-18T10:00:00Z"
 
     # ── Project responses ────────────────────────────────────────────────
 

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -3781,6 +3781,13 @@ components:
         - monitor_group
       description: Resource types that can be assigned to a webhook.
 
+    DeliveryStatus:
+      type: string
+      enum:
+        - SUCCESS
+        - FAILED
+      description: Outcome of a webhook delivery attempt.
+
     BearerAuthDto:
       type: object
       required:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -3109,10 +3109,21 @@ components:
 
         - `generic`: Sends the raw result payload to any HTTPS endpoint.
         - `slack`: Sends a formatted Slack Block Kit message. URL must start with `https://hooks.slack.com/`.
-        - `teams`: Sends a formatted Microsoft Teams Adaptive Card. URL hostname must match `*.webhook.office.com` or `*.webhook.office365.com`.
-        - `custom`: Custom payload transformation. Not yet available.
+        - `teams`: Sends a formatted Microsoft Teams Adaptive Card. URL hostname must match `*webhook.office.com` or `*.webhook.office365.com`.
+        - `custom`: Sends a transformed payload using the configuration in `formatter_config`. Requires `formatter_config` to be set.
 
         When `type` is omitted, it is auto-detected from the URL.
+
+    DeliveryMode:
+      type: string
+      enum:
+        - full
+        - per_record
+      description: |
+        Delivery mode for webhook payloads.
+
+        - `full`: Sends all records in a single request on each trigger.
+        - `per_record`: Sends one request per record. For large result sets, this may generate many requests.
 
     CreateMonitorResponseDto:
       type: object

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -1507,7 +1507,7 @@ components:
       schema:
         type: boolean
         default: false
-        
+
     WebhookId:
       name: webhook_id
       in: path
@@ -3096,6 +3096,23 @@ components:
           minItems: 2
           maxItems: 2
           description: Basic auth credentials [username, password].
+
+    WebhookType:
+      type: string
+      enum:
+        - generic
+        - slack
+        - teams
+        - custom
+      description: |
+        Webhook target type.
+
+        - `generic`: Sends the raw result payload to any HTTPS endpoint.
+        - `slack`: Sends a formatted Slack Block Kit message. URL must start with `https://hooks.slack.com/`.
+        - `teams`: Sends a formatted Microsoft Teams Adaptive Card. URL hostname must match `*.webhook.office.com` or `*.webhook.office365.com`.
+        - `custom`: Custom payload transformation. Not yet available.
+
+        When `type` is omitted, it is auto-detected from the URL.
 
     CreateMonitorResponseDto:
       type: object

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -114,6 +114,7 @@ paths:
         - $ref: "#/components/parameters/PageSize"
         - $ref: "#/components/parameters/Search"
         - $ref: "#/components/parameters/Ownership"
+        - $ref: "#/components/parameters/ProjectIdQuery"
       responses:
         "200":
           $ref: "#/components/responses/ListUserJobsResponse"
@@ -289,6 +290,7 @@ paths:
         - $ref: "#/components/parameters/PageSize"
         - $ref: "#/components/parameters/Search"
         - $ref: "#/components/parameters/Ownership"
+        - $ref: "#/components/parameters/ProjectIdQuery"
       responses:
         "200":
           $ref: "#/components/responses/ListMonitorsResponse"
@@ -831,6 +833,7 @@ paths:
           schema:
             $ref: "#/components/schemas/SortOrder"
         - $ref: "#/components/parameters/Ownership"
+        - $ref: "#/components/parameters/ProjectIdQuery"
       responses:
         "200":
           $ref: "#/components/responses/DatasetListResponse"
@@ -2469,6 +2472,12 @@ components:
 
             Only valid when `connected_dataset_ids` is set; otherwise ignored. Records where no connected entity meets the threshold are excluded entirely.
           example: 3
+        project_id:
+          type: string
+          format: uuid
+          description: |
+            Project to assign this job to. The job appears in the project's resource list immediately after submission.
+          example: "60a85db4-78ec-4b78-876a-bc7d9cdadd04"
 
     SubmitResponseDto:
       type: object
@@ -3004,6 +3013,12 @@ components:
             If true, fills the data gap between the reference job's `end_date` and the first scheduled run. The reference job's `end_date` must be within the last 7 days. 
 
             If false, no gap filling occurs and the first run uses the current cron window only — the reference job's age does not matter.
+        project_id:
+          type: string
+          format: uuid
+          description: |
+            Project to assign this monitor to. The monitor appears in the project's resource list after creation.
+          example: "60a85db4-78ec-4b78-876a-bc7d9cdadd04"
 
     WebhookDto:
       type: object

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -3445,6 +3445,37 @@ components:
           description: Set to `false` to disable delivery without deleting the webhook.
           example: false
 
+    ListWebhooksResponseDto:
+      type: object
+      required:
+        - total
+        - page
+        - page_size
+        - total_pages
+        - webhooks
+      properties:
+        total:
+          type: integer
+          description: Total number of webhooks in the organization.
+          example: 3
+        page:
+          type: integer
+          description: Current page number.
+          example: 1
+        page_size:
+          type: integer
+          description: Number of webhooks per page.
+          example: 100
+        total_pages:
+          type: integer
+          description: Total number of pages available.
+          example: 1
+        webhooks:
+          type: array
+          items:
+            $ref: "#/components/schemas/WebhookResponseDto"
+          description: Webhooks on this page.
+
     CreateMonitorResponseDto:
       type: object
       required:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -3143,6 +3143,64 @@ components:
         - monitor_group
       description: Resource types that can be assigned to a webhook.
 
+      BearerAuthDto:
+      type: object
+      required:
+        - type
+        - token
+      properties:
+        type:
+          type: string
+          enum:
+            - bearer
+          description: Authentication type.
+        token:
+          type: string
+          description: Bearer token sent in the `Authorization` header.
+          example: "my-secret-token"
+
+    ApiKeyAuthDto:
+      type: object
+      required:
+        - type
+        - header
+        - value
+      properties:
+        type:
+          type: string
+          enum:
+            - api_key
+          description: Authentication type.
+        header:
+          type: string
+          description: HTTP header name for the API key.
+          example: "x-api-key"
+        value:
+          type: string
+          description: API key value.
+          example: "sk-abc123"
+
+    BasicAuthDto:
+      type: object
+      required:
+        - type
+        - username
+        - password
+      properties:
+        type:
+          type: string
+          enum:
+            - basic
+          description: Authentication type.
+        username:
+          type: string
+          description: Basic auth username.
+          example: "user"
+        password:
+          type: string
+          description: Basic auth password.
+          example: "pass"
+
     CreateMonitorResponseDto:
       type: object
       required:

--- a/web-search-api/api-reference/catch-all-api.yml
+++ b/web-search-api/api-reference/catch-all-api.yml
@@ -2912,6 +2912,25 @@ components:
         - `too_short`: Query is too short to resolve meaningful search intent.
         - `too_long`: Query is excessively long and may confuse the pipeline.
 
+    Suggestion:
+      type: object
+      description: Actionable recommendation for improving a query.
+      required:
+        - issue
+        - message
+      properties:
+        issue:
+          $ref: "#/components/schemas/IssueType"
+          description: The issue this suggestion addresses.
+        message:
+          type: string
+          description: Specific guidance for improving the query.
+          example: "Add a target sector or geography to narrow the results."
+        example:
+          type: string
+          description: Revised query demonstrating the suggested improvement.
+          example: "Series A fundraising for AI startups in healthcare"
+
     InitializeRequestDto:
       type: object
       required:

--- a/web-search-api/api-reference/jobs/validate-query.mdx
+++ b/web-search-api/api-reference/jobs/validate-query.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api post /catchAll/validate
+---

--- a/web-search-api/api-reference/monitors/webhook-payload.mdx
+++ b/web-search-api/api-reference/monitors/webhook-payload.mdx
@@ -1,6 +1,0 @@
----
-title: Webhook payload
-description: Data model for a payload sent to the webhook URL when a monitor job completes.
-openapi-schema: catch-all-api WebhookPayload
-tag: SCHEMA
----

--- a/web-search-api/api-reference/projects/add-resource.mdx
+++ b/web-search-api/api-reference/projects/add-resource.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api post /catchAll/projects/{project_id}/resources
+---

--- a/web-search-api/api-reference/projects/create-project.mdx
+++ b/web-search-api/api-reference/projects/create-project.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api post /catchAll/projects
+---

--- a/web-search-api/api-reference/projects/delete-project.mdx
+++ b/web-search-api/api-reference/projects/delete-project.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api delete /catchAll/projects/{project_id}
+---

--- a/web-search-api/api-reference/projects/get-project-overview.mdx
+++ b/web-search-api/api-reference/projects/get-project-overview.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api get /catchAll/projects/{project_id}/overview
+---

--- a/web-search-api/api-reference/projects/get-project.mdx
+++ b/web-search-api/api-reference/projects/get-project.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api get /catchAll/projects/{project_id}
+---

--- a/web-search-api/api-reference/projects/list-projects.mdx
+++ b/web-search-api/api-reference/projects/list-projects.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api get /catchAll/projects
+---

--- a/web-search-api/api-reference/projects/list-resources.mdx
+++ b/web-search-api/api-reference/projects/list-resources.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api get /catchAll/projects/{project_id}/resources
+---

--- a/web-search-api/api-reference/projects/remove-resource.mdx
+++ b/web-search-api/api-reference/projects/remove-resource.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api delete /catchAll/projects/{project_id}/resources/{resource_type}/{resource_id}
+---

--- a/web-search-api/api-reference/projects/update-project.mdx
+++ b/web-search-api/api-reference/projects/update-project.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api patch /catchAll/projects/{project_id}
+---

--- a/web-search-api/api-reference/webhooks/assign-resource.mdx
+++ b/web-search-api/api-reference/webhooks/assign-resource.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api post /catchAll/webhooks/{webhook_id}/resources
+---

--- a/web-search-api/api-reference/webhooks/create-webhook.mdx
+++ b/web-search-api/api-reference/webhooks/create-webhook.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api post /catchAll/webhooks
+---

--- a/web-search-api/api-reference/webhooks/delete-webhook.mdx
+++ b/web-search-api/api-reference/webhooks/delete-webhook.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api delete /catchAll/webhooks/{webhook_id}
+---

--- a/web-search-api/api-reference/webhooks/get-delivery-history.mdx
+++ b/web-search-api/api-reference/webhooks/get-delivery-history.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api get /catchAll/webhook-history
+---

--- a/web-search-api/api-reference/webhooks/get-webhook.mdx
+++ b/web-search-api/api-reference/webhooks/get-webhook.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api get /catchAll/webhooks/{webhook_id}
+---

--- a/web-search-api/api-reference/webhooks/list-resource-webhooks.mdx
+++ b/web-search-api/api-reference/webhooks/list-resource-webhooks.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api get /catchAll/resources/{resource_type}/{resource_id}/webhooks
+---

--- a/web-search-api/api-reference/webhooks/list-webhook-resources.mdx
+++ b/web-search-api/api-reference/webhooks/list-webhook-resources.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api get /catchAll/webhooks/{webhook_id}/resources
+---

--- a/web-search-api/api-reference/webhooks/list-webhooks.mdx
+++ b/web-search-api/api-reference/webhooks/list-webhooks.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api get /catchAll/webhooks
+---

--- a/web-search-api/api-reference/webhooks/remove-resource.mdx
+++ b/web-search-api/api-reference/webhooks/remove-resource.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api delete /catchAll/webhooks/{webhook_id}/resources/{resource_type}/{resource_id}
+---

--- a/web-search-api/api-reference/webhooks/test-webhook.mdx
+++ b/web-search-api/api-reference/webhooks/test-webhook.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api post /catchAll/webhooks/{webhook_id}/test
+---

--- a/web-search-api/api-reference/webhooks/update-webhook.mdx
+++ b/web-search-api/api-reference/webhooks/update-webhook.mdx
@@ -1,0 +1,3 @@
+---
+openapi: catch-all-api patch /catchAll/webhooks/{webhook_id}
+---

--- a/web-search-api/api-reference/webhooks/webhook-payload.mdx
+++ b/web-search-api/api-reference/webhooks/webhook-payload.mdx
@@ -1,0 +1,6 @@
+---
+title: Webhook payload
+description: Data model for the payload delivered to a webhook when a monitor job completes.
+openapi-schema: catch-all-api WebhookPayload
+tag: SCHEMA
+---

--- a/web-search-api/get-started/changelog.mdx
+++ b/web-search-api/get-started/changelog.mdx
@@ -5,7 +5,7 @@ description: Track updates, improvements, and fixes to the CatchAll API.
 rss: true
 ---
 
-<Update label="1.6.0" description="2026-05-XX">
+<Update label="1.6.0" description="2026-05-26">
 ## Centralized webhooks, query validation, and projects
 
 Introduces centralized webhook management to replace per-monitor inline

--- a/web-search-api/get-started/changelog.mdx
+++ b/web-search-api/get-started/changelog.mdx
@@ -6,6 +6,50 @@ rss: true
 ---
 
 <Update label="1.6.0" description="2026-05-XX">
+## Centralized webhooks
+
+Replaces per-monitor inline webhook configuration with a reusable, 
+resource-agnostic webhook system.
+
+**Features:**
+
+- **Webhook management**: Create named webhook endpoints at the organization
+  level and reuse them across any number of jobs or monitors.
+- **Flexible assignment**: Pass `webhook_ids` at job or monitor creation time,
+  or assign webhooks to existing resources using the assignment endpoints.
+  Each resource supports up to 5 webhooks.
+- **Delivery modes**: `full` sends all records in a single request per trigger.
+  `per_record` sends one request per record.
+- **Authentication**: Bearer token, API key header, and basic auth are forwarded
+  with each delivery request.
+- **Platform-formatted payloads**: `slack` and `teams` types send pre-formatted
+  Slack Block Kit and Microsoft Teams Adaptive Card payloads automatically.
+- **Test delivery**: Verify endpoint reachability and authentication before
+  attaching a webhook to a live resource.
+
+**New endpoints:**
+
+- [`POST /catchAll/webhooks`](/web-search-api/api-reference/webhooks/create-webhook)
+  — Create a webhook.
+- [`GET /catchAll/webhooks`](/web-search-api/api-reference/webhooks/list-webhooks)
+  — List webhooks.
+- [`GET /catchAll/webhooks/{webhook_id}`](/web-search-api/api-reference/webhooks/get-webhook)
+  — Get a webhook.
+- [`PATCH /catchAll/webhooks/{webhook_id}`](/web-search-api/api-reference/webhooks/update-webhook)
+  — Update a webhook.
+- [`DELETE /catchAll/webhooks/{webhook_id}`](/web-search-api/api-reference/webhooks/delete-webhook)
+  — Delete a webhook.
+- [`POST /catchAll/webhooks/{webhook_id}/test`](/web-search-api/api-reference/webhooks/test-webhook)
+  — Test webhook delivery.
+- [`POST /catchAll/webhooks/{webhook_id}/resources`](/web-search-api/api-reference/webhooks/assign-resource)
+  — Assign a resource to a webhook.
+- [`GET /catchAll/webhooks/{webhook_id}/resources`](/web-search-api/api-reference/webhooks/list-webhook-resources)
+  — List resources assigned to a webhook.
+- [`DELETE /catchAll/webhooks/{webhook_id}/resources/{resource_type}/{resource_id}`](/web-search-api/api-reference/webhooks/remove-resource)
+  — Remove a resource from a webhook.
+- [`GET /catchAll/resources/{resource_type}/{resource_id}/webhooks`](/web-search-api/api-reference/webhooks/list-resource-webhooks)
+  — List webhooks assigned to a resource.
+
 ## Projects
 
 Introduces Projects — a way to organize and share jobs, monitors, and datasets

--- a/web-search-api/get-started/changelog.mdx
+++ b/web-search-api/get-started/changelog.mdx
@@ -5,6 +5,45 @@ description: Track updates, improvements, and fixes to the CatchAll API.
 rss: true
 ---
 
+<Update label="1.6.0" description="2026-05-XX">
+## Projects
+
+Introduces Projects — a way to organize and share jobs, monitors, and datasets
+by use case, team, or client.
+
+**Features:**
+
+- **Projects**: Create named containers for related resources. Assign resources
+  to a project at creation time via the `project_id` field, or post-hoc using
+  the project resources endpoints.
+- **Project filtering**: Filter jobs, monitors, and datasets by project using
+  the `project_id` query parameter on all list endpoints.
+- **Project overview**: Get a status breakdown of all resources in a project
+  without fetching the full resource list.
+
+**Endpoints:**
+
+- [`GET /catchAll/projects`](/web-search-api/api-reference/projects/list-projects)
+  — List projects.
+- [`POST /catchAll/projects`](/web-search-api/api-reference/projects/create-project)
+  — Create a project.
+- [`GET /catchAll/projects/{project_id}`](/web-search-api/api-reference/projects/get-project)
+  — Get a project.
+- [`PATCH /catchAll/projects/{project_id}`](/web-search-api/api-reference/projects/update-project)
+  — Update a project.
+- [`DELETE /catchAll/projects/{project_id}`](/web-search-api/api-reference/projects/delete-project)
+  — Delete a project.
+- [`GET /catchAll/projects/{project_id}/overview`](/web-search-api/api-reference/projects/get-project-overview)
+  — Get resource counts by type and status.
+- [`GET /catchAll/projects/{project_id}/resources`](/web-search-api/api-reference/projects/list-resources)
+  — List resources in a project.
+- [`POST /catchAll/projects/{project_id}/resources`](/web-search-api/api-reference/projects/add-resource)
+  — Add a resource to a project.
+- [`DELETE /catchAll/projects/{project_id}/resources/{resource_type}/{resource_id}`](/web-search-api/api-reference/projects/remove-resource)
+  — Remove a resource from a project.
+
+</Update>
+
 <Update label="1.5.3" description="2026-05-11">
 ## ED score filtering, entity attributes, and monitor timezone
 

--- a/web-search-api/get-started/changelog.mdx
+++ b/web-search-api/get-started/changelog.mdx
@@ -38,7 +38,7 @@ by use case, team, or client.
 - [`GET /catchAll/projects/{project_id}/resources`](/web-search-api/api-reference/projects/list-resources)
   — List resources in a project.
 - [`POST /catchAll/projects/{project_id}/resources`](/web-search-api/api-reference/projects/add-resource)
-  — Add a resource to a project.
+  — Add resources to a project.
 - [`DELETE /catchAll/projects/{project_id}/resources/{resource_type}/{resource_id}`](/web-search-api/api-reference/projects/remove-resource)
   — Remove a resource from a project.
 

--- a/web-search-api/get-started/changelog.mdx
+++ b/web-search-api/get-started/changelog.mdx
@@ -31,6 +31,8 @@ reusable, resource-agnostic webhook system.
   Slack Block Kit and Microsoft Teams Adaptive Card payloads automatically.
 - **Test delivery**: Verify endpoint reachability and authentication before
   attaching a webhook to a live resource.
+- **Delivery history**: Inspect per-dispatch outcomes, HTTP status codes, and 
+  error messages for any job or monitor.
 
 **New endpoints:**
 
@@ -54,6 +56,8 @@ reusable, resource-agnostic webhook system.
   — Remove a resource from a webhook.
 - [`GET /catchAll/resources/{resource_type}/{resource_id}/webhooks`](/web-search-api/api-reference/webhooks/list-resource-webhooks)
   — List webhooks assigned to a resource.
+- [`GET /catchAll/webhook-history`](/web-search-api/api-reference/webhooks/get-delivery-history)
+  — Get webhook delivery history for a resource.
 
 ### Query validation
 

--- a/web-search-api/get-started/changelog.mdx
+++ b/web-search-api/get-started/changelog.mdx
@@ -6,21 +6,26 @@ rss: true
 ---
 
 <Update label="1.6.0" description="2026-05-XX">
-## Centralized webhooks
+## Centralized webhooks, query validation, and projects
 
-Replaces per-monitor inline webhook configuration with a reusable, 
-resource-agnostic webhook system.
+Introduces centralized webhook management to replace per-monitor inline
+configuration, a pre-submission query validation endpoint, and projects for
+organizing and sharing resources.
+
+### Centralized webhooks
+
+Replaces the `webhook` inline field on monitor creation and update with a
+reusable, resource-agnostic webhook system.
 
 **Features:**
 
 - **Webhook management**: Create named webhook endpoints at the organization
   level and reuse them across any number of jobs or monitors.
 - **Flexible assignment**: Pass `webhook_ids` at job or monitor creation time,
-  or assign webhooks to existing resources using the assignment endpoints.
-  Each resource supports up to 5 webhooks.
+  or assign webhooks after creation. Each resource supports up to 5 webhooks.
 - **Delivery modes**: `full` sends all records in a single request per trigger.
   `per_record` sends one request per record.
-- **Authentication**: Bearer token, API key header, and basic auth are forwarded
+- **Authentication**: Bearer token, API key header, and basic auth forwarded
   with each delivery request.
 - **Platform-formatted payloads**: `slack` and `teams` types send pre-formatted
   Slack Block Kit and Microsoft Teams Adaptive Card payloads automatically.
@@ -50,20 +55,29 @@ resource-agnostic webhook system.
 - [`GET /catchAll/resources/{resource_type}/{resource_id}/webhooks`](/web-search-api/api-reference/webhooks/list-resource-webhooks)
   — List webhooks assigned to a resource.
 
-## Projects
+### Query validation
 
-Introduces Projects — a way to organize and share jobs, monitors, and datasets
-by use case, team, or client.
+Adds a pre-submission endpoint that checks whether a query is well-formed
+before creating a job.
+
+**New endpoint:**
+
+- [`POST /catchAll/validate`](/web-search-api/api-reference/jobs/validate-query)
+  — Validate a query before submission.
+
+### Projects
+
+Organizes jobs, monitors, and datasets into named containers that can be
+shared with teammates.
 
 **Features:**
 
-- **Projects**: Create named containers for related resources. Assign resources
-  to a project at creation time via the `project_id` field, or post-hoc using
-  the project resources endpoints.
+- **Resource grouping**: Assign resources to a project at creation time via
+  `project_id`, or post-hoc using the project resources endpoints.
 - **Project filtering**: Filter jobs, monitors, and datasets by project using
   the `project_id` query parameter on all list endpoints.
-- **Project overview**: Get a status breakdown of all resources in a project
-  without fetching the full resource list.
+- **Project overview**: Get a resource status breakdown without fetching the
+  full resource list.
 
 **Endpoints:**
 

--- a/web-search-api/get-started/introduction.mdx
+++ b/web-search-api/get-started/introduction.mdx
@@ -194,6 +194,7 @@ CatchAll processes queries through a multi-stage pipeline that analyzes over
   <Tab title="Jobs">
     | Endpoint                    |  Method  | Description                     |
     | --------------------------- | -------- | ------------------------------- |
+    | `/catchAll/validate`        | `POST`   | Validate a query before submission              |
     | `/catchAll/initialize`      | `POST`   | Get validator, enrichment, and date suggestions |
     | `/catchAll/submit`          | `POST`   | Create a new job                |
     | `/catchAll/continue`        | `POST`   | Continue job with higher limit  |
@@ -213,7 +214,7 @@ CatchAll processes queries through a multi-stage pipeline that analyzes over
     | Endpoint                                    |  Method  | Description                    |
     | ------------------------------------------- | -------- | ------------------------------ |
     | `/catchAll/monitors/create`                 | `POST`   | Create scheduled monitor       |
-    | `/catchAll/monitors/{monitor_id}`           | `PATCH`  | Update monitor webhook         |
+    | `/catchAll/monitors/{monitor_id}`           | `PATCH`  | Update monitor                 |
     | `/catchAll/monitors/{monitor_id}`           | `DELETE` | Delete a monitor               |
     | `/catchAll/monitors`                        | `GET`    | List all monitors              |
     | `/catchAll/monitors/{monitor_id}/jobs`      | `GET`    | List jobs for a monitor        |
@@ -221,6 +222,22 @@ CatchAll processes queries through a multi-stage pipeline that analyzes over
     | `/catchAll/monitors/pull/{monitor_id}`      | `GET`    | Get aggregated monitor results |
     | `/catchAll/monitors/{monitor_id}/enable`    | `POST`   | Enable a monitor               |
     | `/catchAll/monitors/{monitor_id}/disable`   | `POST`   | Disable a monitor              |
+  </Tab>
+
+  <Tab title="Webhooks">
+    | Endpoint                                                                          | Method   | Description                              |
+    | --------------------------------------------------------------------------------- | -------- | ---------------------------------------- |
+    | `/catchAll/webhooks`                                                              | `POST`   | Create a webhook                         |
+    | `/catchAll/webhooks`                                                              | `GET`    | List webhooks                            |
+    | `/catchAll/webhooks/{webhook_id}`                                                 | `GET`    | Get a webhook                            |
+    | `/catchAll/webhooks/{webhook_id}`                                                 | `PATCH`  | Update a webhook                         |
+    | `/catchAll/webhooks/{webhook_id}`                                                 | `DELETE` | Delete a webhook                         |
+    | `/catchAll/webhooks/{webhook_id}/test`                                            | `POST`   | Test webhook delivery                    |
+    | `/catchAll/webhooks/{webhook_id}/resources`                                       | `POST`   | Assign a resource to a webhook           |
+    | `/catchAll/webhooks/{webhook_id}/resources`                                       | `GET`    | List resources assigned to a webhook     |
+    | `/catchAll/webhooks/{webhook_id}/resources/{resource_type}/{resource_id}`         | `DELETE` | Remove a resource from a webhook         |
+    | `/catchAll/resources/{resource_type}/{resource_id}/webhooks`                      | `GET`    | List webhooks assigned to a resource     |
+    | `/catchAll/webhook-history`                                                       | `GET`    | Get webhook delivery history             |
   </Tab>
 
   <Tab title="Entities">
@@ -248,6 +265,20 @@ CatchAll processes queries through a multi-stage pipeline that analyzes over
     | `/catchAll/datasets/{dataset_id}/entities/list` | `POST`    | List entities in dataset                 |
     | `/catchAll/datasets/{dataset_id}/status`        | `GET`    | Get dataset status history               |
     | `/catchAll/datasets/{dataset_id}/upload`        | `POST`   | Add companies to dataset via CSV         |
+  </Tab>
+
+  <Tab title="Projects">
+    | Endpoint                                                                      | Method   | Description                              |
+    | ----------------------------------------------------------------------------- | -------- | ---------------------------------------- |
+    | `/catchAll/projects`                                                          | `POST`   | Create a project                         |
+    | `/catchAll/projects`                                                          | `GET`    | List projects                            |
+    | `/catchAll/projects/{project_id}`                                             | `GET`    | Get a project                            |
+    | `/catchAll/projects/{project_id}`                                             | `PATCH`  | Update a project                         |
+    | `/catchAll/projects/{project_id}`                                             | `DELETE` | Delete a project                         |
+    | `/catchAll/projects/{project_id}/overview`                                    | `GET`    | Get resource counts by type and status   |
+    | `/catchAll/projects/{project_id}/resources`                                   | `POST`   | Add resources to a project               |
+    | `/catchAll/projects/{project_id}/resources`                                   | `GET`    | List resources in a project              |
+    | `/catchAll/projects/{project_id}/resources/{resource_type}/{resource_id}`     | `DELETE` | Remove a resource from a project         |
   </Tab>
 
   <Tab title="Meta">

--- a/web-search-api/get-started/quickstart.mdx
+++ b/web-search-api/get-started/quickstart.mdx
@@ -41,7 +41,7 @@ Before you begin, make sure you meet these prerequisites:
 
     ```bash Java (Gradle)
     dependencies {
-        implementation 'com.newscatcherapi:newscatcher-catchall-sdk:1.1.2'
+        implementation 'com.newscatcherapi:newscatcher-catchall-sdk:3.0.0'
     }
     ```
 
@@ -49,7 +49,7 @@ Before you begin, make sure you meet these prerequisites:
     <dependency>
         <groupId>com.newscatcherapi</groupId>
         <artifactId>newscatcher-catchall-sdk</artifactId>
-        <version>1.1.2</version>
+        <version>3.0.0</version>
     </dependency>
     ```
     </CodeGroup>
@@ -111,7 +111,7 @@ Before you begin, make sure you meet these prerequisites:
     // Create a job
     const job = await client.jobs.createJob({
       query: "AI company acquisitions",
-      context: "Focus on deal size and acquiring company details"
+      context: "Focus on deal size and acquiring company details",
       start_date: "2025-12-03T19:00:40Z",
       end_date: "2025-12-08T19:00:40Z",
       limit: 10

--- a/web-search-api/guides-and-concepts/monitors.mdx
+++ b/web-search-api/guides-and-concepts/monitors.mdx
@@ -10,14 +10,14 @@ notifications when new results are available.
 
 ## How it works
 
-Each scheduled execution:
+Each scheduled execution does the following:
 
 - Creates a new job with its own `job_id`.
 - Uses a rolling date window based on schedule frequency.
 - Applies the reference job's validators, extractors, and schema.
 - Deduplicates records across all runs and merges the results.
 
-## Before you start
+## Before you begin
 
 Create a successful job following the [Quickstart guide](/web-search-api/get-started/quickstart).
 
@@ -40,10 +40,7 @@ curl -X POST "https://catchall.newscatcherapi.com/catchAll/monitors/create" \
   -d '{
     "reference_job_id": "295b95d8-6041-4f4b-b132-9f009fc6af70",
     "schedule": "every day at 12 PM UTC",
-    "webhook": {
-      "url": "https://your-endpoint.com/catchall",
-      "method": "POST"
-    }
+    "webhook_ids": ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"]
   }'
 ```
 
@@ -51,10 +48,7 @@ curl -X POST "https://catchall.newscatcherapi.com/catchAll/monitors/create" \
 {
   "reference_job_id": "295b95d8-6041-4f4b-b132-9f009fc6af70",
   "schedule": "every day at 12 PM UTC",
-  "webhook": {
-    "url": "https://your-endpoint.com/catchall",
-    "method": "POST"
-  }
+  "webhook_ids": ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"]
 }
 ```
 
@@ -67,10 +61,7 @@ client = CatchAllApi(api_key="YOUR_API_KEY")
 monitor = client.monitors.create_monitor(
     reference_job_id="295b95d8-6041-4f4b-b132-9f009fc6af70",
     schedule="every day at 12 PM UTC",
-    webhook={
-        "url": "https://your-endpoint.com/catchall",
-        "method": "POST"
-    }
+    webhook_ids=["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
 )
 
 monitor_id = monitor.monitor_id
@@ -85,10 +76,7 @@ const client = new CatchAllApiClient({ apiKey: "YOUR_API_KEY" });
 const monitor = await client.monitors.createMonitor({
   reference_job_id: "295b95d8-6041-4f4b-b132-9f009fc6af70",
   schedule: "every day at 12 PM UTC",
-  webhook: {
-    url: "https://your-endpoint.com/catchall",
-    method: "POST",
-  },
+  webhook_ids: ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
 });
 
 const monitorId = monitor.monitor_id;
@@ -108,10 +96,7 @@ var monitor = client.monitors().createMonitor(
     CreateMonitorRequestDto.builder()
         .referenceJobId("295b95d8-6041-4f4b-b132-9f009fc6af70")
         .schedule("every day at 12 PM UTC")
-        .webhook(WebhookDto.builder()
-            .url("https://your-endpoint.com/catchall")
-            .method("POST")
-            .build())
+        .webhookIds(List.of("a1b2c3d4-e5f6-7890-abcd-ef1234567890"))
         .build()
 );
 
@@ -130,101 +115,14 @@ Response:
 ```
 
 <Note>
-  The `webhook` parameter is optional. For webhook payload structure and
-  authentication options, see the [Webhooks](#webhooks) section.
-</Note>
-
-### Update monitor webhook
-
-Modify webhook configuration for an existing monitor without recreating it:
-
-<CodeGroup>
-```bash cURL
-curl -X PATCH "https://catchall.newscatcherapi.com/catchAll/monitors/{monitor_id}" \
-  -H "x-api-key: YOUR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "webhook": {
-      "url": "https://new-endpoint.com/webhook",
-      "method": "POST",
-      "headers": {"Authorization": "Bearer NEW_TOKEN"}
-    }
-  }'
-```
-```python Python
-from newscatcher_catchall import CatchAllApi
-
-client = CatchAllApi(api_key="YOUR_API_KEY")
-monitor_id = "3fec5b07-8786-46d7-9486-d43ff67eccd4"
-
-# Update webhook configuration
-client.monitors.update_monitor(
-    monitor_id=monitor_id,
-    webhook={
-        "url": "https://new-endpoint.com/webhook",
-        "method": "POST",
-        "headers": {"Authorization": "Bearer NEW_TOKEN"}
-    }
-)
-```
-```typescript TypeScript
-import { CatchAllApiClient } from "newscatcher-catchall-sdk";
-
-const client = new CatchAllApiClient({ apiKey: "YOUR_API_KEY" });
-const monitorId = "3fec5b07-8786-46d7-9486-d43ff67eccd4";
-
-// Update webhook configuration
-await client.monitors.updateMonitor({
-  monitor_id: monitorId,
-  webhook: {
-    url: "https://new-endpoint.com/webhook",
-    method: "POST",
-    headers: { Authorization: "Bearer NEW_TOKEN" }
-  }
-});
-```
-```java Java
-import com.newscatcher.catchall.CatchAllApi;
-import com.newscatcher.catchall.resources.monitors.requests.UpdateMonitorRequestDto;
-import com.newscatcher.catchall.types.WebhookDto;
-import java.util.Map;
-
-CatchAllApi client = CatchAllApi.builder()
-    .apiKey("YOUR_API_KEY")
-    .build();
-
-String monitorId = "3fec5b07-8786-46d7-9486-d43ff67eccd4";
-
-// Update webhook configuration
-client.monitors().updateMonitor(
-    monitorId,
-    UpdateMonitorRequestDto.builder()
-        .webhook(WebhookDto.builder()
-            .url("https://new-endpoint.com/webhook")
-            .method("POST")
-            .headers(Map.of("Authorization", "Bearer NEW_TOKEN"))
-            .build())
-        .build()
-);
-```
-
-</CodeGroup>
-
-Response:
-
-```json
-{
-  "monitor_id": "3fec5b07-8786-46d7-9486-d43ff67eccd4",
-  "status": "Monitor updated Successfully"
-}
-```
-
-<Note>
-  **Schedule and reference job cannot be modified.** To change the query or schedule, 
-  create a new monitor.
+  Webhooks are configured separately and attached via `webhook_ids`. For 
+  instructions, see [Set up webhooks](/web-search-api/how-to/set-up-webhooks).
 </Note>
 
 ## Retrieve results
+
+Use these endpoints to list monitors, inspect execution history, and pull 
+aggregated records.
 
 ### List monitors
 
@@ -494,6 +392,80 @@ Response:
 
 ## Manage monitors
 
+Use these endpoints to update webhook assignments, pause, resume, or delete a 
+monitor, and inspect its execution history.
+
+### Update monitor
+
+Update webhook assignments or the record limit for an existing monitor. Pass a 
+new list of webhook IDs to replace existing assignments. Pass an empty array to 
+clear all assignments:
+
+<CodeGroup>
+```bash cURL
+curl -X PATCH "https://catchall.newscatcherapi.com/catchAll/monitors/{monitor_id}" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "webhook_ids": ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+    "limit": 100
+  }'
+```
+```python Python
+from newscatcher_catchall import CatchAllApi
+
+client = CatchAllApi(api_key="YOUR_API_KEY")
+
+client.monitors.update_monitor(
+    monitor_id="3fec5b07-8786-46d7-9486-d43ff67eccd4",
+    webhook_ids=["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+    limit=100
+)
+```
+```typescript TypeScript
+import { CatchAllApiClient } from "newscatcher-catchall-sdk";
+
+const client = new CatchAllApiClient({ apiKey: "YOUR_API_KEY" });
+
+await client.monitors.updateMonitor({
+  monitor_id: "3fec5b07-8786-46d7-9486-d43ff67eccd4",
+  webhook_ids: ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+  limit: 100
+});
+```
+```java Java
+import com.newscatcher.catchall.CatchAllApi;
+import com.newscatcher.catchall.resources.monitors.requests.UpdateMonitorRequestDto;
+import java.util.List;
+
+CatchAllApi client = CatchAllApi.builder()
+    .apiKey("YOUR_API_KEY")
+    .build();
+
+client.monitors().updateMonitor(
+    "3fec5b07-8786-46d7-9486-d43ff67eccd4",
+    UpdateMonitorRequestDto.builder()
+        .webhookIds(List.of("a1b2c3d4-e5f6-7890-abcd-ef1234567890"))
+        .limit(100)
+        .build()
+);
+```
+</CodeGroup>
+
+Response:
+
+```json
+{
+  "monitor_id": "3fec5b07-8786-46d7-9486-d43ff67eccd4",
+  "status": "Monitor updated Successfully"
+}
+```
+
+<Note>
+  Schedule and reference job cannot be modified. To change the query or schedule, 
+  create a new monitor.
+</Note>
+
 ### Enable monitor
 
 Resume execution of a disabled monitor:
@@ -752,125 +724,9 @@ history.getStatuses().forEach(entry ->
 
 </Expandable>
 
-## Webhooks
-
-To get HTTP notifications for completed monitor jobs, add a `webhook` when 
-creating the monitor (see [Create a monitor](#create-a-monitor)). You can update 
-the webhook at any time using [update monitor webhook](#update-monitor-webhook) 
-without recreating the monitor.
-
-### Webhook payload
-
-<Expandable title="full payload structure">
-
-When a monitor job completes, your endpoint receives:
-
-```json
-{
-  "monitor_id": "3fec5b07-8786-46d7-9486-d43ff67eccd4",
-  "reference_job_id": "295b95d8-6041-4f4b-b132-9f009fc6af70",
-  "latest_job_id": "e2dd78b0-3189-48f3-9011-eef0ecd9aced",
-  "records_count": 2,
-  "jobs_processed": 3,
-  "updated_at": "2025-11-07T11:25:33.877039",
-  "cron_expression": "*/5 * * * *",
-  "timezone": "UTC",
-  "records": [
-    {
-      "record_id": "-39216465981207817",
-      "record_title": "Homeplus Seeks Buyer, Receives LOI from AI Firm Harex Infotech",
-      "added_on": "2025-11-07T11:25:33Z",
-      "enrichment": {
-        "schema_based_summary": "Harex Infotech acquired Homeplus Co. for null on null",
-        "acquisition_date": null,
-        "deal_type": "acquisition",
-        "deal_status": "in talks",
-        "confidence": "high",
-        "acquired_company": "Homeplus Co.",
-        "acquiring_company": "Harex Infotech"
-      },
-      "citations": [
-        {
-          "title": "Court extends Homeplus' rehabilitation plan submission deadline",
-          "link": "https://n.news.naver.com/mnews/article/009/0005586304",
-          "published_date": "2025-11-07T11:21:21Z",
-          "job_id": "e2dd78b0-3189-48f3-9011-eef0ecd9aced",
-          "added_on": "2025-11-07T11:25:33Z"
-        }
-      ]
-    }
-  ]
-}
-```
-
-**Key fields:**
-
-- `latest_job_id`: Use to retrieve full job results via
-  `/catchAll/pull/{job_id}`
-- `records_count`: Number of new records in this execution (after deduplication)
-- `jobs_processed`: Total number of jobs executed by this monitor
-- `records`: Array of new records from the latest job
-- `records[].added_on`: Timestamp when this record was first collected
-- `records[].citations[].added_on`: Timestamp when this citation was added
-
-<Note>
-  Webhooks fire on every job completion, even when `records_count` is 0 (no new
-  events after deduplication).
-</Note>
-
-</Expandable>
-
-### Authentication
-
-<Expandable title="authentication examples">
-
-**Bearer token:**
-
-```json
-{
-  "webhook": {
-    "url": "https://api.example.com/catchall",
-    "method": "POST",
-    "headers": {
-      "Authorization": "Bearer YOUR_TOKEN",
-      "Content-Type": "application/json"
-    }
-  }
-}
-```
-
-**Basic authentication:**
-
-```json
-{
-  "webhook": {
-    "url": "https://your-endpoint.com/webhook",
-    "method": "POST",
-    "auth": ["username", "password"]
-  }
-}
-```
-
-**Custom headers:**
-
-```json
-{
-  "webhook": {
-    "url": "https://your-endpoint.com/webhook",
-    "method": "POST",
-    "headers": {
-      "X-Custom-Header": "value",
-      "X-API-Key": "your-key",
-      "Content-Type": "application/json"
-    }
-  }
-}
-```
-
-</Expandable>
-
 ## See also
 
-- [API reference](/web-search-api/api-reference/monitors/create-monitor)
+- [Set up webhooks](/web-search-api/how-to/set-up-webhooks)
 - [Configure monitors](/web-search-api/how-to/configure-monitors)
-- [Troubleshoot monitors](/web-search-api/how-to/troubleshoot-monitors)
+- [Webhook payload](/web-search-api/api-reference/webhooks/webhook-payload)
+- [API reference](/web-search-api/api-reference/monitors/create-monitor)

--- a/web-search-api/guides-and-concepts/projects.mdx
+++ b/web-search-api/guides-and-concepts/projects.mdx
@@ -14,8 +14,8 @@ Resources can be assigned to a project in two ways:
 
 - **At creation time** — include `project_id` in the request body of any
   create endpoint for jobs, monitors, or datasets.
-- **Post-hoc** — use the [Add resource](/web-search-api/api-reference/projects/add-resource)
-  endpoint to assign any existing resource by type and ID.
+- **Post-hoc** — use the [Add resources](/web-search-api/api-reference/projects/add-resource)
+  endpoint to assign one or more existing resources by type and ID.
 
 Each resource belongs to at most one project. Entities cannot be assigned to
 projects — they are shared across the entire organization.
@@ -104,8 +104,12 @@ curl -X POST "https://catchall.newscatcherapi.com/catchAll/projects/60a85db4-78e
   -H "x-api-key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "resource_type": "job",
-    "resource_id": "48421e16-1f50-4048-b62c-d3bc0789d30d"
+    "resources": [
+      {
+        "resource_type": "job",
+        "resource_id": "48421e16-1f50-4048-b62c-d3bc0789d30d"
+      }
+    ]
   }'
 ```
 

--- a/web-search-api/guides-and-concepts/projects.mdx
+++ b/web-search-api/guides-and-concepts/projects.mdx
@@ -1,0 +1,204 @@
+---
+title: Projects
+sidebarTitle: Projects
+description: Organize jobs, monitors, and datasets into named groups for easier management and sharing.
+---
+
+A project is a named container for jobs, monitors, and datasets. Use projects
+to separate work by use case, team, or client — and to share that work with
+teammates across your organization.
+
+## How it works
+
+Resources can be assigned to a project in two ways:
+
+- **At creation time** — include `project_id` in the request body of any
+  create endpoint for jobs, monitors, or datasets.
+- **Post-hoc** — use the [Add resource](/web-search-api/api-reference/projects/add-resource)
+  endpoint to assign any existing resource by type and ID.
+
+Each resource belongs to at most one project. Entities cannot be assigned to
+projects — they are shared across the entire organization.
+
+## Create a project
+
+<CodeGroup>
+```bash cURL
+curl -X POST "https://catchall.newscatcherapi.com/catchAll/projects" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "AI M&A Tracking",
+    "description": "Tracks AI-related M&A activity for our investment team."
+  }'
+```
+```python Python
+from newscatcher_catchall import CatchAllApi
+
+client = CatchAllApi(api_key="YOUR_API_KEY")
+
+project = client.projects.create_project(
+    name="AI M&A Tracking",
+    description="Tracks AI-related M&A activity for our investment team.",
+)
+project_id = project.project_id
+```
+```typescript TypeScript
+import { CatchAllApiClient } from "newscatcher-catchall-sdk";
+
+const client = new CatchAllApiClient({ apiKey: "YOUR_API_KEY" });
+
+const project = await client.projects.createProject({
+  name: "AI M&A Tracking",
+  description: "Tracks AI-related M&A activity for our investment team.",
+});
+const projectId = project.project_id;
+```
+```java Java
+import com.newscatcher.catchall.CatchAllApi;
+import com.newscatcher.catchall.resources.projects.requests.CreateProjectRequestDto;
+
+CatchAllApi client = CatchAllApi.builder()
+    .apiKey("YOUR_API_KEY")
+    .build();
+
+var project = client.projects().createProject(
+    CreateProjectRequestDto.builder()
+        .name("AI M&A Tracking")
+        .description("Tracks AI-related M&A activity for our investment team.")
+        .build()
+);
+String projectId = project.getProjectId();
+```
+</CodeGroup>
+
+Response:
+
+```json
+{
+  "success": true,
+  "message": "Project created successfully.",
+  "project_id": "60a85db4-78ec-4b78-876a-bc7d9cdadd04",
+  "name": "AI M&A Tracking"
+}
+```
+
+## Assign resources
+
+Pass `project_id` in the request body at creation time:
+
+```bash cURL
+curl -X POST "https://catchall.newscatcherapi.com/catchAll/submit" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "AI acquisitions and mergers Q2 2026",
+    "project_id": "60a85db4-78ec-4b78-876a-bc7d9cdadd04"
+  }'
+```
+
+To add an existing resource post-hoc:
+
+```bash cURL
+curl -X POST "https://catchall.newscatcherapi.com/catchAll/projects/60a85db4-78ec-4b78-876a-bc7d9cdadd04/resources" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "resource_type": "job",
+    "resource_id": "48421e16-1f50-4048-b62c-d3bc0789d30d"
+  }'
+```
+
+## Filter by project
+
+All list endpoints accept a `project_id` query parameter to return only
+resources belonging to a specific project:
+
+<Tabs>
+  <Tab title="Jobs">
+    ```bash
+    curl "https://catchall.newscatcherapi.com/catchAll/jobs/user?project_id=60a85db4-78ec-4b78-876a-bc7d9cdadd04" \
+      -H "x-api-key: YOUR_API_KEY"
+    ```
+  </Tab>
+  <Tab title="Monitors">
+    ```bash
+    curl "https://catchall.newscatcherapi.com/catchAll/monitors?project_id=60a85db4-78ec-4b78-876a-bc7d9cdadd04" \
+      -H "x-api-key: YOUR_API_KEY"
+    ```
+  </Tab>
+  <Tab title="Datasets">
+    ```bash
+    curl "https://catchall.newscatcherapi.com/catchAll/datasets?project_id=60a85db4-78ec-4b78-876a-bc7d9cdadd04" \
+      -H "x-api-key: YOUR_API_KEY"
+    ```
+  </Tab>
+</Tabs>
+
+## Get a project overview
+
+Returns resource counts grouped by type and status — useful for dashboards
+without fetching full resource lists:
+
+```bash cURL
+curl "https://catchall.newscatcherapi.com/catchAll/projects/60a85db4-78ec-4b78-876a-bc7d9cdadd04/overview" \
+  -H "x-api-key: YOUR_API_KEY"
+```
+
+```json
+{
+  "project_id": "60a85db4-78ec-4b78-876a-bc7d9cdadd04",
+  "overview": {
+    "jobs": {
+      "completed": 12,
+      "failed": 1,
+      "analyzing": 2
+    },
+    "monitors": {
+      "completed": 3
+    },
+    "datasets": {
+      "total": 2
+    },
+    "monitor_groups": {
+      "total": 0
+    }
+  }
+}
+```
+
+For `jobs` and `monitors`, keys are status values with integer counts. For
+`datasets` and `monitor_groups`, only a `total` count is returned.
+
+## Delete a project
+
+By default, deleting a project unassigns its resources — they continue to exist
+without a project association. Set `delete_resources=true` to permanently delete
+all assigned resources along with the project.
+
+<Tabs>
+  <Tab title="Unassign resources (default)">
+    ```bash
+    curl -X DELETE "https://catchall.newscatcherapi.com/catchAll/projects/60a85db4-78ec-4b78-876a-bc7d9cdadd04" \
+      -H "x-api-key: YOUR_API_KEY"
+    ```
+  </Tab>
+  <Tab title="Delete project and resources">
+    ```bash
+    curl -X DELETE "https://catchall.newscatcherapi.com/catchAll/projects/60a85db4-78ec-4b78-876a-bc7d9cdadd04?delete_resources=true" \
+      -H "x-api-key: YOUR_API_KEY"
+    ```
+  </Tab>
+</Tabs>
+
+<Warning>
+  `delete_resources=true` permanently deletes all jobs, monitors, and datasets
+  assigned to the project. This operation cannot be undone.
+</Warning>
+
+## See also
+
+- [Projects API reference](/web-search-api/api-reference/projects/create-project)
+- [Jobs](/web-search-api/guides-and-concepts/jobs)
+- [Monitors](/web-search-api/guides-and-concepts/monitors)
+- [Company search](/web-search-api/guides-and-concepts/company-search)

--- a/web-search-api/how-to/configure-monitors.mdx
+++ b/web-search-api/how-to/configure-monitors.mdx
@@ -415,120 +415,111 @@ Log all webhook events for debugging:
 
 ## Update monitor configuration
 
-Modify webhook settings for existing monitors without recreating them.
+Update webhook assignments or the record limit for an existing monitor without
+recreating it.
 
 ### When to update
 
-Update monitor webhooks when you need to:
-- Change webhook endpoint URL
-- Modify authentication headers
-- Switch HTTP method (POST/PUT)
-- Update query parameters
+Update a monitor when you need to:
+- Change which webhooks receive notifications
+- Clear all webhook assignments
+- Adjust the maximum records per run
 
 <Note>
-  **Schedule and reference job cannot be modified.** To change the query or schedule, 
+  Schedule and reference job cannot be modified. To change the query or schedule,
   create a new monitor.
 </Note>
 
 ### Update procedure
 
 <Steps>
-  <Step title="Prepare new webhook config">
-    Define your updated webhook configuration with new URL, headers, or method.
+  <Step title="Get the webhook ID">
+    If you don't have the webhook ID, list your webhooks:
+
+```bash
+    curl "https://catchall.newscatcherapi.com/catchAll/webhooks" \
+      -H "x-api-key: YOUR_API_KEY"
+```
   </Step>
 
   <Step title="Send update request">
 
-<Tabs>
-  <Tab title="Python">
-```python
-    from newscatcher_catchall import CatchAllApi
-
-    client = CatchAllApi(api_key="YOUR_API_KEY")
-    monitor_id = "3fec5b07-8786-46d7-9486-d43ff67eccd4"
-
-    # Update webhook
-    response = client.monitors.update_monitor(
-        monitor_id=monitor_id,
-        webhook={
-            "url": "https://new-endpoint.com/webhook",
-            "method": "POST",
-            "headers": {"Authorization": "Bearer NEW_TOKEN"}
-        }
-    )
-    print(f"Updated: {response.monitor_id}")
+<CodeGroup>
+```bash cURL
+curl -X PATCH "https://catchall.newscatcherapi.com/catchAll/monitors/{monitor_id}" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "webhook_ids": ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+    "limit": 100
+  }'
 ```
-  </Tab>
+```python Python
+from newscatcher_catchall import CatchAllApi
 
-  <Tab title="TypeScript">
-```typescript
-    import { CatchAllApiClient } from "newscatcher-catchall-sdk";
+client = CatchAllApi(api_key="YOUR_API_KEY")
 
-    const client = new CatchAllApiClient({ apiKey: "YOUR_API_KEY" });
-    const monitorId = "3fec5b07-8786-46d7-9486-d43ff67eccd4";
-
-    // Update webhook
-    const response = await client.monitors.updateMonitor({
-      monitor_id: monitorId,
-      webhook: {
-        url: "https://new-endpoint.com/webhook",
-        method: "POST",
-        headers: { Authorization: "Bearer NEW_TOKEN" }
-      }
-    });
-    console.log(`Updated: ${response.monitor_id}`);
+response = client.monitors.update_monitor(
+    monitor_id="3fec5b07-8786-46d7-9486-d43ff67eccd4",
+    webhook_ids=["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+    limit=100,
+)
+print(f"Updated: {response.monitor_id}")
 ```
-  </Tab>
+```typescript TypeScript
+import { CatchAllApiClient } from "newscatcher-catchall-sdk";
 
-  <Tab title="Java">
-```java
-    import com.newscatcher.catchall.CatchAllApi;
-    import com.newscatcher.catchall.resources.monitors.requests.UpdateMonitorRequestDto;
-    import com.newscatcher.catchall.types.WebhookDto;
-    import java.util.Map;
+const client = new CatchAllApiClient({ apiKey: "YOUR_API_KEY" });
 
-    CatchAllApi client = CatchAllApi.builder()
-        .apiKey("YOUR_API_KEY")
-        .build();
-
-    String monitorId = "3fec5b07-8786-46d7-9486-d43ff67eccd4";
-
-    // Update webhook
-    var response = client.monitors().updateMonitor(
-        monitorId,
-        UpdateMonitorRequestDto.builder()
-            .webhook(WebhookDto.builder()
-                .url("https://new-endpoint.com/webhook")
-                .method("POST")
-                .headers(Map.of("Authorization", "Bearer NEW_TOKEN"))
-                .build())
-            .build()
-    );
-    System.out.println("Updated: " + response.getMonitorId().orElse("N/A"));
+const response = await client.monitors.updateMonitor({
+  monitor_id: "3fec5b07-8786-46d7-9486-d43ff67eccd4",
+  webhook_ids: ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+  limit: 100,
+});
+console.log(`Updated: ${response.monitor_id}`);
 ```
-  </Tab>
-</Tabs>
+```java Java
+import com.newscatcher.catchall.CatchAllApi;
+import com.newscatcher.catchall.resources.monitors.requests.UpdateMonitorRequestDto;
+import java.util.List;
+
+CatchAllApi client = CatchAllApi.builder()
+    .apiKey("YOUR_API_KEY")
+    .build();
+
+var response = client.monitors().updateMonitor(
+    "3fec5b07-8786-46d7-9486-d43ff67eccd4",
+    UpdateMonitorRequestDto.builder()
+        .webhookIds(List.of("a1b2c3d4-e5f6-7890-abcd-ef1234567890"))
+        .limit(100)
+        .build()
+);
+System.out.println("Updated: " + response.getMonitorId().orElse("N/A"));
+```
+</CodeGroup>
+
+To clear all webhook assignments, pass an empty array: `"webhook_ids": []`.
 
   </Step>
 
   <Step title="Verify update">
-    List your monitors to confirm the webhook configuration was updated:
+    List your monitors to confirm the change took effect:
+
 ```bash
     curl "https://catchall.newscatcherapi.com/catchAll/monitors" \
       -H "x-api-key: YOUR_API_KEY"
 ```
-    
-    Check the `webhook` field in the response.
   </Step>
 </Steps>
 
 <Tip>
-  Updates take effect immediately. The next scheduled execution uses the new webhook 
+  Updates take effect immediately. The next scheduled execution uses the new
   configuration.
 </Tip>
 
 ## See also
 
+- [Set up webhooks](/web-search-api/how-to/set-up-webhooks)
 - [Monitors overview](/web-search-api/guides-and-concepts/monitors)
 - [Troubleshoot monitors](/web-search-api/how-to/troubleshoot-monitors)
 - [API reference](/web-search-api/api-reference/monitors/create-monitor)

--- a/web-search-api/how-to/set-up-webhooks.mdx
+++ b/web-search-api/how-to/set-up-webhooks.mdx
@@ -1,0 +1,438 @@
+---
+title: Set up webhooks
+sidebarTitle: Set up webhooks
+description: Create and manage webhooks to receive real-time notifications when jobs and monitors complete.
+---
+
+This guide covers how to create, test, and update a webhook, attach it to a job 
+or monitor, and troubleshoot delivery issues.
+
+## Before you begin
+
+- You have a CatchAll API key.
+- You have a publicly accessible HTTPS endpoint ready to receive POST requests,
+  or use [webhook.site](https://webhook.site) for testing.
+
+## Create webhook
+
+A webhook is created independently of any job or monitor. Once created, you
+attach it to one or more resources.
+
+<CodeGroup>
+```bash cURL
+curl -X POST "https://catchall.newscatcherapi.com/catchAll/webhooks" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Layoffs Alert",
+    "url": "https://your-endpoint.com/catchall",
+    "type": "generic",
+    "delivery_mode": "full"
+  }'
+```
+```python Python
+from newscatcher_catchall import CatchAllApi
+
+client = CatchAllApi(api_key="YOUR_API_KEY")
+
+webhook = client.webhooks.create_webhook(
+    name="Layoffs Alert",
+    url="https://your-endpoint.com/catchall",
+    type="generic",
+    delivery_mode="full",
+)
+print(f"Webhook created: {webhook.webhook.id}")
+```
+```typescript TypeScript
+import { CatchAllApiClient } from "newscatcher-catchall-sdk";
+
+const client = new CatchAllApiClient({ apiKey: "YOUR_API_KEY" });
+
+const response = await client.webhooks.createWebhook({
+  name: "Layoffs Alert",
+  url: "https://your-endpoint.com/catchall",
+  type: "generic",
+  delivery_mode: "full",
+});
+console.log(`Webhook created: ${response.webhook.id}`);
+```
+```java Java
+import com.newscatcher.catchall.CatchAllApi;
+import com.newscatcher.catchall.resources.webhooks.requests.CreateWebhookRequestDto;
+import com.newscatcher.catchall.types.WebhookType;
+import com.newscatcher.catchall.types.DeliveryMode;
+
+CatchAllApi client = CatchAllApi.builder()
+    .apiKey("YOUR_API_KEY")
+    .build();
+
+var response = client.webhooks().createWebhook(
+    CreateWebhookRequestDto.builder()
+        .name("Layoffs Alert")
+        .url("https://your-endpoint.com/catchall")
+        .type(WebhookType.GENERIC)
+        .deliveryMode(DeliveryMode.FULL)
+        .build()
+);
+System.out.println("Webhook created: " + response.getWebhook().getId());
+```
+</CodeGroup>
+
+Response:
+
+```json
+{
+  "success": true,
+  "message": "Webhook created successfully.",
+  "webhook": {
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "name": "Layoffs Alert",
+    "url": "https://your-endpoint.com/catchall",
+    "type": "generic",
+    "delivery_mode": "full",
+    "method": "POST",
+    "is_active": true
+  }
+}
+```
+
+Save the `webhook.id` — you use it to attach the webhook to resources.
+
+For supported values of `type`, `delivery_mode`, and `auth`, see 
+[Create webhook API reference](/web-search-api/api-reference/webhooks/create-webhook).
+
+## Test before attaching
+
+Before attaching a webhook to a live resource, verify that your endpoint is
+reachable and auth is configured correctly:
+
+<CodeGroup>
+```bash cURL
+curl -X POST "https://catchall.newscatcherapi.com/catchAll/webhooks/{webhook_id}/test" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+```python Python
+result = client.webhooks.test_webhook(webhook_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+print(f"Status: {result.http_status_code}, Success: {result.success}")
+```
+```typescript TypeScript
+const result = await client.webhooks.testWebhook({
+  webhook_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+});
+console.log(`Status: ${result.http_status_code}, Success: ${result.success}`);
+```
+```java Java
+var result = client.webhooks().testWebhook("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+System.out.println("Status: " + result.getHttpStatusCode() + ", Success: " + result.getSuccess());
+```
+</CodeGroup>
+
+Response:
+
+```json
+{
+  "success": true,
+  "message": "Test delivery succeeded.",
+  "http_status_code": 200,
+  "response_body": "ok"
+}
+```
+
+If `success` is `false`, check `http_status_code` and `response_body` to
+diagnose the issue before proceeding.
+
+## Attach webhook to job or monitor
+
+You can attach a webhook to a job or monitor at creation time, or assign it to 
+an existing resource afterward.
+
+### At creation time
+
+Pass `webhook_ids` when submitting a job or creating a monitor:
+
+<CodeGroup>
+```bash cURL — job
+curl -X POST "https://catchall.newscatcherapi.com/catchAll/submit" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "Tech layoffs in the US",
+    "webhook_ids": ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"]
+  }'
+```
+```bash cURL — monitor
+curl -X POST "https://catchall.newscatcherapi.com/catchAll/monitors/create" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "reference_job_id": "5f0c9087-85cb-4917-b3c7-e5a5eff73a0c",
+    "schedule": "every day at 9 AM UTC",
+    "webhook_ids": ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"]
+  }'
+```
+```python Python
+# Attach to a job at submission
+job = client.jobs.submit_job(
+    query="Tech layoffs in the US",
+    webhook_ids=["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+)
+
+# Attach to a monitor at creation
+monitor = client.monitors.create_monitor(
+    reference_job_id="5f0c9087-85cb-4917-b3c7-e5a5eff73a0c",
+    schedule="every day at 9 AM UTC",
+    webhook_ids=["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+)
+```
+```typescript TypeScript
+// Attach to a job at submission
+const job = await client.jobs.submitJob({
+  query: "Tech layoffs in the US",
+  webhook_ids: ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+});
+
+// Attach to a monitor at creation
+const monitor = await client.monitors.createMonitor({
+  reference_job_id: "5f0c9087-85cb-4917-b3c7-e5a5eff73a0c",
+  schedule: "every day at 9 AM UTC",
+  webhook_ids: ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+});
+```
+```java Java
+// Attach to a job at submission
+var job = client.jobs().submitJob(
+    SubmitRequestDto.builder()
+        .query("Tech layoffs in the US")
+        .webhookIds(List.of("a1b2c3d4-e5f6-7890-abcd-ef1234567890"))
+        .build()
+);
+
+// Attach to a monitor at creation
+var monitor = client.monitors().createMonitor(
+    CreateMonitorRequestDto.builder()
+        .referenceJobId("5f0c9087-85cb-4917-b3c7-e5a5eff73a0c")
+        .schedule("every day at 9 AM UTC")
+        .webhookIds(List.of("a1b2c3d4-e5f6-7890-abcd-ef1234567890"))
+        .build()
+);
+```
+</CodeGroup>
+
+### After creation
+
+Assign a webhook to an existing resource using the assignment endpoint:
+
+<CodeGroup>
+```bash cURL
+curl -X POST "https://catchall.newscatcherapi.com/catchAll/webhooks/{webhook_id}/resources" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "resource_type": "monitor",
+    "resource_id": "3fec5b07-8786-46d7-9486-d43ff67eccd4"
+  }'
+```
+```python Python
+client.webhooks.assign_webhook_resource(
+    webhook_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    resource_type="monitor",
+    resource_id="3fec5b07-8786-46d7-9486-d43ff67eccd4",
+)
+```
+```typescript TypeScript
+await client.webhooks.assignWebhookResource({
+  webhook_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  resource_type: "monitor",
+  resource_id: "3fec5b07-8786-46d7-9486-d43ff67eccd4",
+});
+```
+```java Java
+client.webhooks().assignWebhookResource(
+    "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    AssignWebhookResourceRequestDto.builder()
+        .resourceType(MappableResourceType.MONITOR)
+        .resourceId("3fec5b07-8786-46d7-9486-d43ff67eccd4")
+        .build()
+);
+```
+</CodeGroup>
+
+<Note>
+  Each resource supports up to 5 webhooks. Each webhook can be assigned to
+  multiple resources.
+</Note>
+
+## Update webhook
+
+Update any field on an existing webhook. Only supplied fields are changed:
+
+<CodeGroup>
+```bash cURL
+curl -X PATCH "https://catchall.newscatcherapi.com/catchAll/webhooks/{webhook_id}" \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://new-endpoint.com/catchall",
+    "auth": {
+      "type": "bearer",
+      "token": "NEW_TOKEN"
+    }
+  }'
+```
+```python Python
+client.webhooks.update_webhook(
+    webhook_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    url="https://new-endpoint.com/catchall",
+    auth={"type": "bearer", "token": "NEW_TOKEN"},
+)
+```
+```typescript TypeScript
+await client.webhooks.updateWebhook({
+  webhook_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  url: "https://new-endpoint.com/catchall",
+  auth: { type: "bearer", token: "NEW_TOKEN" },
+});
+```
+```java Java
+client.webhooks().updateWebhook(
+    "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    UpdateWebhookRequestDto.builder()
+        .url("https://new-endpoint.com/catchall")
+        .auth(BearerAuthDto.builder()
+            .type("bearer")
+            .token("NEW_TOKEN")
+            .build())
+        .build()
+);
+```
+</CodeGroup>
+
+To pause deliveries without deleting the webhook, set `is_active` to `false`.
+
+## Handle deliveries
+
+Your endpoint must meet the following requirements and handle incoming requests 
+reliably.
+
+### Endpoint requirements
+
+Your endpoint must:
+
+1. **Return a 2xx status code** within 5 seconds.
+2. **Be publicly accessible** — localhost and private network addresses are not supported.
+3. **Use HTTPS** — HTTP endpoints are not accepted.
+4. **Accept POST requests** with a JSON body.
+
+### Return 200 immediately
+
+Return `200` before processing to avoid timeouts. Process the payload
+asynchronously:
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    from flask import Flask, request, jsonify
+
+    app = Flask(__name__)
+
+    @app.route("/catchall/webhook", methods=["POST"])
+    def handle_webhook():
+        payload = request.json
+        # Return 200 immediately, then process
+        process_async(payload)
+        return jsonify({"status": "received"}), 200
+
+    def process_async(payload):
+        # Your processing logic here
+        pass
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import express from "express";
+
+    const app = express();
+    app.use(express.json());
+
+    app.post("/catchall/webhook", (req, res) => {
+      const payload = req.body;
+      // Return 200 immediately, then process
+      res.status(200).json({ status: "received" });
+      processAsync(payload);
+    });
+
+    async function processAsync(payload: any) {
+      // Your processing logic here
+    }
+    ```
+  </Tab>
+  <Tab title="Java">
+    ```java
+    @RestController
+    public class WebhookController {
+
+        @PostMapping("/catchall/webhook")
+        public ResponseEntity<Map<String, String>> handleWebhook(
+            @RequestBody Map<String, Object> payload
+        ) {
+            // Return 200 immediately, then process
+            CompletableFuture.runAsync(() -> processAsync(payload));
+            return ResponseEntity.ok(Map.of("status", "received"));
+        }
+
+        private void processAsync(Map<String, Object> payload) {
+            // Your processing logic here
+        }
+    }
+    ```
+  </Tab>
+</Tabs>
+
+## Debug deliveries
+
+Use the delivery history endpoint to inspect past dispatch outcomes:
+
+<CodeGroup>
+```bash cURL
+curl "https://catchall.newscatcherapi.com/catchAll/webhook-history?resource_type=monitor&resource_id={monitor_id}" \
+  -H "x-api-key: YOUR_API_KEY"
+```
+```python Python
+history = client.webhooks.get_webhook_delivery_history(
+    resource_type="monitor",
+    resource_id="3fec5b07-8786-46d7-9486-d43ff67eccd4",
+)
+for item in history.items:
+    print(f"{item.timestamp} — {item.delivery_status} ({item.status_code})")
+```
+```typescript TypeScript
+const history = await client.webhooks.getWebhookDeliveryHistory({
+  resource_type: "monitor",
+  resource_id: "3fec5b07-8786-46d7-9486-d43ff67eccd4",
+});
+for (const item of history.items) {
+  console.log(`${item.timestamp} — ${item.delivery_status} (${item.status_code})`);
+}
+```
+```java Java
+var history = client.webhooks().getWebhookDeliveryHistory(
+    MappableResourceType.MONITOR,
+    "3fec5b07-8786-46d7-9486-d43ff67eccd4"
+);
+for (var item : history.getItems()) {
+    System.out.println(item.getTimestamp() + " — " + item.getDeliveryStatus()
+        + " (" + item.getStatusCode() + ")");
+}
+```
+</CodeGroup>
+
+Each record shows the HTTP status code returned by your endpoint, the delivery
+outcome (`SUCCESS` or `FAILED`), and any error or warning messages.
+
+## See also
+
+- [Webhook payload](/web-search-api/api-reference/webhooks/webhook-payload)
+- [Webhooks API reference](/web-search-api/api-reference/webhooks/create-webhook)
+- [Configure monitors](/web-search-api/how-to/configure-monitors)

--- a/web-search-api/libraries/java.mdx
+++ b/web-search-api/libraries/java.mdx
@@ -471,11 +471,7 @@ Automate recurring queries with scheduled execution.
         CreateMonitorRequestDto.builder()
             .referenceJobId(jobId)
             .schedule("every day at 12 PM UTC")
-            .webhook(WebhookDto.builder()
-                .url("https://your-endpoint.com/webhook")
-                .method(WebhookDtoMethod.POST)
-                .headers(Map.of("Authorization", "Bearer YOUR_TOKEN"))
-                .build())
+            .webhookIds(List.of("a1b2c3d4-e5f6-7890-abcd-ef1234567890"))
             .build()
     );
     System.out.println("Monitor created: " + monitor.getMonitorId().orElse("N/A"));
@@ -499,11 +495,8 @@ Automate recurring queries with scheduled execution.
     UpdateMonitorResponseDto updated = client.monitors().updateMonitor(
         monitorId,
         UpdateMonitorRequestDto.builder()
-            .webhook(WebhookDto.builder()
-                .url("https://new-endpoint.com/webhook")
-                .method(WebhookDtoMethod.POST)
-                .headers(Map.of("Authorization", "Bearer NEW_TOKEN"))
-                .build())
+            .webhookIds(List.of("b2c3d4e5-f6a7-8901-bcde-f12345678901"))
+            .limit(100)
             .build()
     );
     System.out.println("Monitor updated: " + updated.getStatus());
@@ -605,11 +598,7 @@ public class MonitorExample {
                 CreateMonitorRequestDto.builder()
                     .referenceJobId(jobId)
                     .schedule("every day at 12 PM UTC")
-                    .webhook(WebhookDto.builder()
-                        .url("https://your-endpoint.com/webhook")
-                        .method(WebhookDtoMethod.POST)
-                        .headers(Map.of("Authorization", "Bearer YOUR_TOKEN"))
-                        .build())
+                    .webhookIds(List.of("a1b2c3d4-e5f6-7890-abcd-ef1234567890"))
                     .build()
             );
             String monitorId = monitor.getMonitorId().orElseThrow();
@@ -619,10 +608,8 @@ public class MonitorExample {
             client.monitors().updateMonitor(
                 monitorId,
                 UpdateMonitorRequestDto.builder()
-                    .webhook(WebhookDto.builder()
-                        .url("https://new-endpoint.com/webhook")
-                        .method(WebhookDtoMethod.POST)
-                        .build())
+                    .webhookIds(List.of("b2c3d4e5-f6a7-8901-bcde-f12345678901"))
+                    .limit(100)
                     .build()
             );
 
@@ -668,9 +655,9 @@ public class MonitorExample {
 ```
 </Accordion>
 
-## Company search
+## Company watchlist
 
-Company search lets you track specific companies across jobs. Create entities,
+Company watchlist lets you track specific companies across jobs. Create entities,
 group them into a dataset, then connect the dataset to any job to get per-company
 relevance scores in results.
 

--- a/web-search-api/libraries/java.mdx
+++ b/web-search-api/libraries/java.mdx
@@ -12,7 +12,7 @@ Java SDK provides access to the CatchAll API from Java applications.
   <Tab title="Gradle">
     ```groovy
     dependencies {
-        implementation 'com.newscatcherapi:newscatcher-catchall-sdk:1.4.0'
+        implementation 'com.newscatcherapi:newscatcher-catchall-sdk:3.0.0'
     }
     ```
   </Tab>
@@ -22,7 +22,7 @@ Java SDK provides access to the CatchAll API from Java applications.
     <dependency>
         <groupId>com.newscatcherapi</groupId>
         <artifactId>newscatcher-catchall-sdk</artifactId>
-        <version>1.4.0</version>
+        <version>3.0.0</version>
     </dependency>
     ```
   </Tab>

--- a/web-search-api/libraries/python.mdx
+++ b/web-search-api/libraries/python.mdx
@@ -369,11 +369,7 @@ Automate recurring queries with scheduled execution.
     monitor = client.monitors.create_monitor(
         reference_job_id=job_id,
         schedule="every day at 12 PM UTC",
-        webhook={
-            "url": "https://your-endpoint.com/webhook",
-            "method": "POST",
-            "headers": {"Authorization": "Bearer YOUR_TOKEN"},
-        },
+        webhook_ids=["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
     )
     print(f"Monitor created: {monitor.monitor_id}")
     ```
@@ -390,11 +386,8 @@ Automate recurring queries with scheduled execution.
     ```python
     updated = client.monitors.update_monitor(
         monitor_id=monitor.monitor_id,
-        webhook={
-            "url": "https://new-endpoint.com/webhook",
-            "method": "POST",
-            "headers": {"Authorization": "Bearer NEW_TOKEN"},
-        },
+        webhook_ids=["b2c3d4e5-f6a7-8901-bcde-f12345678901"],
+        limit=100,
     )
     print(f"Monitor updated: {updated.status}")
     ```
@@ -464,11 +457,7 @@ try:
     monitor = client.monitors.create_monitor(
         reference_job_id=job_id,
         schedule="every day at 12 PM UTC",
-        webhook={
-            "url": "https://your-endpoint.com/webhook",
-            "method": "POST",
-            "headers": {"Authorization": "Bearer YOUR_TOKEN"},
-        },
+        webhook_ids=["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
     )
     monitor_id = monitor.monitor_id
     print(f"Monitor created: {monitor_id}")
@@ -476,10 +465,8 @@ try:
     # Update webhook
     client.monitors.update_monitor(
         monitor_id=monitor_id,
-        webhook={
-            "url": "https://new-endpoint.com/webhook",
-            "method": "POST",
-        },
+        webhook_ids=["b2c3d4e5-f6a7-8901-bcde-f12345678901"],
+        limit=100,
     )
 
     # List all monitors
@@ -514,9 +501,9 @@ except ApiError as e:
 ```
 </Accordion>
 
-## Company search
+## Company watchlist
 
-Company search lets you track specific companies across jobs. Create entities,
+Company watchlist lets you track specific companies across jobs. Create entities,
 group them into a dataset, then connect the dataset to any job to get per-company
 relevance scores in results.
 

--- a/web-search-api/libraries/typescript.mdx
+++ b/web-search-api/libraries/typescript.mdx
@@ -389,11 +389,7 @@ Automate recurring queries with scheduled execution.
     const monitor = await client.monitors.createMonitor({
       reference_job_id: jobId,
       schedule: "every day at 12 PM UTC",
-      webhook: {
-        url: "https://your-endpoint.com/webhook",
-        method: "POST",
-        headers: { Authorization: "Bearer YOUR_TOKEN" },
-      },
+      webhook_ids: ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
     });
     console.log(`Monitor created: ${monitor.monitor_id}`);
     ```
@@ -410,11 +406,8 @@ Automate recurring queries with scheduled execution.
     ```typescript
     const updated = await client.monitors.updateMonitor({
       monitor_id: monitor.monitor_id,
-      webhook: {
-        url: "https://new-endpoint.com/webhook",
-        method: "POST",
-        headers: { Authorization: "Bearer NEW_TOKEN" },
-      },
+      webhook_ids: ["b2c3d4e5-f6a7-8901-bcde-f12345678901"],
+      limit: 100,
     });
     console.log(`Monitor updated: ${updated.status}`);
     ```
@@ -486,11 +479,7 @@ try {
   const monitor = await client.monitors.createMonitor({
     reference_job_id: jobId,
     schedule: "every day at 12 PM UTC",
-    webhook: {
-      url: "https://your-endpoint.com/webhook",
-      method: "POST",
-      headers: { Authorization: "Bearer YOUR_TOKEN" },
-    },
+    webhook_ids: ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
   });
   const monitorId = monitor.monitor_id;
   console.log(`Monitor created: ${monitorId}`);
@@ -498,10 +487,8 @@ try {
   // Update webhook
   await client.monitors.updateMonitor({
     monitor_id: monitorId,
-    webhook: {
-      url: "https://new-endpoint.com/webhook",
-      method: "POST",
-    },
+    webhook_ids: ["b2c3d4e5-f6a7-8901-bcde-f12345678901"],
+    limit: 100,
   });
 
   // List all monitors
@@ -542,9 +529,9 @@ try {
 ```
 </Accordion>
 
-## Company search
+## Company watchlist
 
-Company search lets you track specific companies across jobs. Create entities,
+Company watchlist lets you track specific companies across jobs. Create entities,
 group them into a dataset, then connect the dataset to any job to get per-company
 relevance scores in results.
 


### PR DESCRIPTION
## What

Adds complete documentation coverage for three features shipped in CatchAll API v1.6.0 — centralized webhook management, query validation, and projects — including OAS updates, API reference pages, how-to guides, and updates to all affected existing docs.

## Why

All three features are live. Developers have no public reference for the new webhook endpoints, the `webhook_ids` field on job and monitor creation, the `/validate` endpoint, or the `project_id` field and Projects endpoints. Existing monitor docs referenced the removed inline `webhook` field.

## Changes

**OAS (`catch-all-api.yml`)**
- Add `Webhooks` tag and 11 new endpoint paths under `# ── Webhooks ──`
- Add 14 new webhook schemas (enums, request/response DTOs, auth types)
- Add 3 webhook path parameter components and 8 webhook response components
- Add `webhook_ids` to `SubmitRequestDto`, `CreateMonitorRequestDto`, and `UpdateMonitorRequestDto`; remove inline `webhook` field from both monitor schemas
- Add `QueryStatus`, `IssueType`, `Suggestion`, `ValidateQueryRequestDto`, `ValidateQueryResponseDto` schemas
- Add `POST /catchAll/validate` path under Jobs
- Add `DeliveryStatus`, `DeliveryHistoryItemDto`, `DeliveryHistoryResponseDto` schemas
- Add `GET /catchAll/webhook-history` path
- Add `Projects` tag, 3 shared parameters, 8 response definitions, 14 schemas
- Add 9 new endpoint paths under `# ── Projects ──`
- Add `project_id` to `SubmitRequestDto` and `CreateMonitorRequestDto`
- Add `?project_id=` filter to `GET /catchAll/jobs/user`, `/monitors`, `/datasets`
- Add webhook workflow to `info.description`

**New pages**
- Add `how-to/set-up-webhooks.mdx` — full how-to guide covering create, test, attach, update, handle deliveries, and debug
- Add 12 MDX stubs under `web-search-api/api-reference/webhooks/`
- Add `validate-query.mdx` to Jobs API reference
- Add 9 MDX stubs under `web-search-api/api-reference/projects/`
- Add `guides-and-concepts/projects.mdx`

**Navigation (`docs.json`)**
- Add `Webhooks` group to API Reference with 12 pages
- Move `webhook-payload.mdx` from `monitors/` to `webhooks/`; add redirect rule
- Add `validate-query` to Jobs group
- Add `set-up-webhooks` to How-to group
- Add `Projects` group to API Reference and Guides and concepts

**Updated existing docs**
- `guides-and-concepts/monitors.mdx` — rewrite webhook section: replace inline `webhook` object with `webhook_ids`, update all SDK examples, remove auth expandable, update See also
- `how-to/configure-monitors.mdx` — rewrite "Update monitor configuration" section: replace old `webhook` inline examples with `webhook_ids` + `limit`, update "When to update" rationale, add `set-up-webhooks` to See also
- `get-started/introduction.mdx` — add `/catchAll/validate` to Jobs tab, fix Monitors PATCH description, add Webhooks tab, add Projects tab
- `libraries/python.mdx` — update create and update monitor examples to use `webhook_ids`; fix Java version placeholder
- `libraries/typescript.mdx` — same
- `libraries/java.mdx` — same; replace hardcoded SDK version with `VERSION` placeholder and Maven Central link

**Changelog**
- Add `1.6.0` entry with `##` release heading and `###` subsections for Centralized webhooks, Query validation, and Projects

## Testing

- Webhook `custom` type validated against `catchall.newscatcherapi.dev` — confirms `formatter_config` required
- `/validate` endpoint tested with `good`, `needs_work`, and `critical` queries — response shapes confirmed against backend source
- All Projects endpoints tested against dev — confirmed in prior PR
- Monitor SDK examples derived from OAS + existing patterns; to be validated against regenerated SDKs before merge

## Notes

- **SDK validation pending**: library page examples for `webhook_ids`, `webhooks.createWebhook`, and `webhooks.assignWebhookResource` are derived from the OAS. Share regenerated SDKs for signature validation before merging.
- `GET /catchAll/webhook-history` response shape authored from the internal `webhook_status` table — not yet in FastAPI-generated spec.
- `WebhookDto` remains in the OAS — still referenced by `MonitorListItemResponseDto`.
- The inline `webhook` field removal from `CreateMonitorRequestDto` should be verified in the crafted OAS before merge — both `webhook` and `webhook_ids` may still be present.

Suggested review order: `catch-all-api.yml` → `docs.json` → `api-reference/webhooks/` → `api-reference/jobs/validate-query.mdx` → `api-reference/projects/` → `how-to/set-up-webhooks.mdx` → `guides-and-concepts/monitors.mdx` → `how-to/configure-monitors.mdx` → `get-started/introduction.mdx` → `libraries/` → `changelog.mdx`