### PR TITLE
docs: add "Send events to Slack" how-to + step-level ToC on how-to pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -61,7 +61,8 @@
               "web-search-api/how-to/configure-monitors",
               "web-search-api/how-to/troubleshoot-monitors",
               "web-search-api/how-to/build-an-event-feed",
-              "web-search-api/how-to/monitor-a-portfolio"
+              "web-search-api/how-to/monitor-a-portfolio",
+              "web-search-api/how-to/send-events-to-slack"
             ]
           },
           {

--- a/llms.txt
+++ b/llms.txt
@@ -29,6 +29,7 @@
 - [Troubleshoot monitors](https://www.newscatcherapi.com/docs/web-search-api/how-to/troubleshoot-monitors): Diagnose and fix common monitor issues.
 - [Build a recurring event feed](https://www.newscatcherapi.com/docs/web-search-api/how-to/build-an-event-feed): Go from a one-off query to a scheduled monitor that delivers fresh event records to your app every day.
 - [Monitor a portfolio of companies](https://www.newscatcherapi.com/docs/web-search-api/how-to/monitor-a-portfolio): Turn a list of companies into a scheduled watchlist that delivers fresh, per-company news to your app every day.
+- [Send events to Slack](https://www.newscatcherapi.com/docs/web-search-api/how-to/send-events-to-slack): Post CatchAll results straight to a Slack channel as formatted messages, with no endpoint to build or host.
 
 ### API Reference — Jobs
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -49,6 +49,9 @@
         <loc>https://www.newscatcherapi.com/docs/web-search-api/how-to/monitor-a-portfolio</loc>
     </url>
     <url>
+        <loc>https://www.newscatcherapi.com/docs/web-search-api/how-to/send-events-to-slack</loc>
+    </url>
+    <url>
         <loc>https://www.newscatcherapi.com/docs/web-search-api/api-reference/jobs/validate-query</loc>
     </url>
     <url>

--- a/web-search-api/how-to/build-an-event-feed.mdx
+++ b/web-search-api/how-to/build-an-event-feed.mdx
@@ -36,8 +36,10 @@ dependencies {
 ```
 </CodeGroup>
 
+## Build the feed
+
 <Steps>
-  <Step title="Test the query">
+  <Step title="Test the query" titleSize="h3">
     Submit your query as a one-off job and review the results before committing it to
     a schedule. Keep the `job_id`; you reference it when creating the monitor.
 
@@ -141,7 +143,7 @@ dependencies {
     </Note>
   </Step>
 
-  <Step title="Create a webhook">
+  <Step title="Create a webhook" titleSize="h3">
     A webhook is created once at the organization level, then attached to any number of
     jobs or monitors. Save the returned `webhook.id`.
 
@@ -202,7 +204,7 @@ dependencies {
     </Tip>
   </Step>
 
-  <Step title="Schedule a monitor">
+  <Step title="Schedule a monitor" titleSize="h3">
     A monitor re-runs your query on a schedule, deduplicates against previous runs, and
     delivers each run to the webhooks in `webhook_ids`.
 
@@ -258,7 +260,7 @@ dependencies {
     </Warning>
   </Step>
 
-  <Step title="Handle the delivery">
+  <Step title="Handle the delivery" titleSize="h3">
     After each scheduled run, CatchAll sends a POST to your webhook URL. Return a 2xx
     within 5 seconds and process asynchronously.
 

--- a/web-search-api/how-to/monitor-a-portfolio.mdx
+++ b/web-search-api/how-to/monitor-a-portfolio.mdx
@@ -42,8 +42,10 @@ dependencies {
 ```
 </CodeGroup>
 
+## Build the monitor
+
 <Steps>
-  <Step title="Build the watchlist">
+  <Step title="Build the watchlist" titleSize="h3">
     A dataset is a named collection of company entities — your portfolio. The fastest
     way to create one is to upload a CSV: it creates the entities and the dataset in a
     single request. The `name` and `domain` columns are required; everything else is
@@ -118,7 +120,7 @@ dependencies {
     </Tip>
   </Step>
 
-  <Step title="Wait for the dataset to be ready">
+  <Step title="Wait for the dataset to be ready" titleSize="h3">
     Entities are enriched after upload. Poll the dataset until `latest_status` reaches
     `ready` — don't submit a job before this completes.
 
@@ -168,7 +170,7 @@ dependencies {
     </CodeGroup>
   </Step>
 
-  <Step title="Test a connected job">
+  <Step title="Test a connected job" titleSize="h3">
     Run the watchlist once before scheduling it. Submit a standard job with
     `connected_dataset_ids` to activate company search mode. To collect all news about
     your companies rather than a single topic, set `fetch_all_watchlist_news: true`;
@@ -261,7 +263,7 @@ dependencies {
     </Note>
   </Step>
 
-  <Step title="Create a webhook">
+  <Step title="Create a webhook" titleSize="h3">
     A webhook is created once at the organization level, then attached to any number of
     jobs or monitors. Save the returned `webhook.id`.
 
@@ -322,7 +324,7 @@ dependencies {
     </Tip>
   </Step>
 
-  <Step title="Schedule the monitor">
+  <Step title="Schedule the monitor" titleSize="h3">
     A monitor re-runs the connected job on a schedule, deduplicates against previous
     runs, and delivers each run to the webhooks in `webhook_ids`. A monitor created from
     a watchlist job keeps the connection — every run scores the same portfolio.
@@ -379,7 +381,7 @@ dependencies {
     </Warning>
   </Step>
 
-  <Step title="Handle the delivery">
+  <Step title="Handle the delivery" titleSize="h3">
     After each scheduled run, CatchAll sends a POST to your webhook URL. Return a 2xx
     within 5 seconds and process asynchronously. For a connected watchlist, each record
     carries the same `connected_entities` array you saw when testing — so you can route

--- a/web-search-api/how-to/send-events-to-slack.mdx
+++ b/web-search-api/how-to/send-events-to-slack.mdx
@@ -1,0 +1,169 @@
+---
+title: "Send events to Slack"
+description: "Post CatchAll results straight to a Slack channel as formatted messages, with no endpoint to build or host."
+---
+
+CatchAll can post results directly to Slack as formatted messages. You don't need
+to build or host an endpoint: create a webhook of type `slack`, point it at a Slack
+incoming webhook URL, and attach it to a job or monitor.
+
+## Before you begin
+
+- Get a CatchAll API key from [platform.newscatcherapi.com](https://platform.newscatcherapi.com/).
+- Create a Slack incoming webhook in your workspace and copy its URL — it starts with `https://hooks.slack.com/`. If you haven't set one up, follow Slack's guide, [Sending messages using incoming webhooks](https://api.slack.com/messaging/webhooks).
+
+## Set up Slack delivery
+
+<Steps>
+  <Step title="Create a Slack webhook" titleSize="h3">
+    Set `type` to `slack` and use your Slack incoming webhook URL. CatchAll formats
+    each delivery as a Slack Block Kit message automatically.
+
+    <CodeGroup>
+    ```bash cURL
+    curl -X POST "https://catchall.newscatcherapi.com/catchAll/webhooks" \
+      -H "x-api-key: YOUR_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "name": "Fintech deals to #deal-flow",
+        "url": "https://hooks.slack.com/services/T000/B000/XXXXXXXX",
+        "type": "slack",
+        "delivery_mode": "full"
+      }'
+    ```
+
+    ```python Python
+    from newscatcher_catchall import CatchAllApi
+
+    client = CatchAllApi(api_key="YOUR_API_KEY")
+
+    webhook = client.webhooks.create_webhook(
+        name="Fintech deals to #deal-flow",
+        url="https://hooks.slack.com/services/T000/B000/XXXXXXXX",
+        type="slack",
+        delivery_mode="full",
+    )
+    webhook_id = webhook.webhook.id
+    ```
+
+    ```typescript TypeScript
+    import { CatchAllApiClient } from "newscatcher-catchall-sdk";
+
+    const client = new CatchAllApiClient({ apiKey: "YOUR_API_KEY" });
+
+    const created = await client.webhooks.createWebhook({
+      name: "Fintech deals to #deal-flow",
+      url: "https://hooks.slack.com/services/T000/B000/XXXXXXXX",
+      type: "slack",
+      delivery_mode: "full",
+    });
+    const webhookId = created.webhook.id;
+    ```
+
+    ```java Java
+    import com.newscatcher.catchall.CatchAllApi;
+    import com.newscatcher.catchall.resources.webhooks.requests.CreateWebhookRequestDto;
+    import com.newscatcher.catchall.types.WebhookType;
+    import com.newscatcher.catchall.types.DeliveryMode;
+
+    CatchAllApi client = CatchAllApi.builder().apiKey("YOUR_API_KEY").build();
+
+    var created = client.webhooks().createWebhook(
+        CreateWebhookRequestDto.builder()
+            .name("Fintech deals to #deal-flow")
+            .url("https://hooks.slack.com/services/T000/B000/XXXXXXXX")
+            .type(WebhookType.SLACK)
+            .deliveryMode(DeliveryMode.FULL)
+            .build()
+    );
+    String webhookId = created.getWebhook().getId();
+    ```
+    </CodeGroup>
+
+    <Tip>
+      Verify the webhook before attaching it with
+      `POST /catchAll/webhooks/{webhook_id}/test`. A test message in the channel
+      confirms the URL works. See [Set up webhooks](/web-search-api/how-to/set-up-webhooks#test-before-attaching).
+    </Tip>
+  </Step>
+
+  <Step title="Choose how messages arrive" titleSize="h3">
+    `delivery_mode` controls batching:
+
+    - `full` (default): one Slack message per run, listing all new records. Best for a daily digest.
+    - `per_record`: one Slack message per record. Best when each event should be actionable on its own.
+
+    <Warning>
+      With `per_record`, a run that returns many records posts that many Slack messages.
+      Use `full` for high-volume feeds to avoid flooding the channel and hitting Slack
+      rate limits.
+    </Warning>
+  </Step>
+
+  <Step title="Attach it to a job or monitor" titleSize="h3">
+    Pass the webhook ID in `webhook_ids` when you create a monitor (for a recurring
+    feed) or submit a job (for a one-off run).
+
+    <CodeGroup>
+    ```bash cURL
+    curl -X POST "https://catchall.newscatcherapi.com/catchAll/monitors/create" \
+      -H "x-api-key: YOUR_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "reference_job_id": "YOUR_JOB_ID",
+        "schedule": "every day at 9 AM UTC",
+        "webhook_ids": ["YOUR_WEBHOOK_ID"]
+      }'
+    ```
+
+    ```python Python
+    monitor = client.monitors.create_monitor(
+        reference_job_id="YOUR_JOB_ID",
+        schedule="every day at 9 AM UTC",
+        webhook_ids=[webhook_id],
+    )
+    ```
+
+    ```typescript TypeScript
+    const monitor = await client.monitors.createMonitor({
+      reference_job_id: "YOUR_JOB_ID",
+      schedule: "every day at 9 AM UTC",
+      webhook_ids: [webhookId],
+    });
+    ```
+
+    ```java Java
+    import com.newscatcher.catchall.resources.monitors.requests.CreateMonitorRequestDto;
+    import java.util.List;
+
+    var monitor = client.monitors().createMonitor(
+        CreateMonitorRequestDto.builder()
+            .referenceJobId("YOUR_JOB_ID")
+            .schedule("every day at 9 AM UTC")
+            .webhookIds(List.of(webhookId))
+            .build()
+    );
+    ```
+    </CodeGroup>
+
+    <Note>
+      Need to build the job and monitor first? See
+      [Build a recurring event feed](/web-search-api/how-to/build-an-event-feed) for the
+      full query → monitor → delivery pipeline.
+    </Note>
+  </Step>
+</Steps>
+
+## Other destinations
+
+Microsoft Teams works the same way: use `type: teams` with a `*.webhook.office.com`
+URL — CatchAll posts a formatted Adaptive Card. For Google Sheets, a database, or a
+CRM, create a `generic` webhook pointing at an automation tool
+([n8n](/web-search-api/integrations/n8n), [Make](/web-search-api/integrations/make),
+or Zapier) and map the records to your destination there.
+
+## See also
+
+- [Set up webhooks](/web-search-api/how-to/set-up-webhooks): webhook types, auth, testing, and delivery history
+- [Build a recurring event feed](/web-search-api/how-to/build-an-event-feed): the full job → monitor → delivery pipeline
+- [Configure monitors](/web-search-api/how-to/configure-monitors): schedules and reliable delivery


### PR DESCRIPTION
## Summary
Adds a new how-to, **Send events to Slack**, to the **Web Search API → How to** group. It shows the no-endpoint path to getting CatchAll results into Slack: create a `slack`-type webhook pointed at a Slack incoming webhook URL, pick `full` vs `per_record` delivery, and attach it to a job or monitor. Closes with Teams (`type: teams`) and generic/automation-tool destinations.

## Files changed
- `web-search-api/how-to/send-events-to-slack.mdx` — new page (4-language CodeGroups, Steps, Tip/Warning/Note, See also).
- `docs.json` — appended the page to the How to group.
- `llms.txt` / `sitemap.xml` — regenerated (both pass `--check`).

## Verified
- Both sync scripts exit 0 and `--check` clean.
- All internal links resolve, including the `#test-before-attaching` anchor on Set up webhooks.
- `type: slack` / `teams`, the `hooks.slack.com` and `*.webhook.office.com` URL rules, Block Kit / Adaptive Card formatting, `full` / `per_record`, and the `/test` endpoint were all checked against the live OpenAPI spec (`catch-all-api.yml`) and the Set up webhooks page.

## Reviewer checklist (for Maksym)
- [ ] Content is accurate and reads in house style
- [ ] Sidebar position (last in How to) makes sense, or move it
- [ ] Code examples match the published `newscatcher-catchall-sdk@3.x`
- [ ] Slack incoming-webhook external link is the one we want to point users to

## Decisions made
- Added a `per_record` flooding/rate-limit warning that wasn't in the original draft, since Slack enforces incoming-webhook rate limits.
- Kept this PR independent of the "Watch a portfolio" PR (#124). Both append to the end of the How to group, so whichever merges second may need a one-line rebase on `docs.json` — trivial, no content overlap.

---
Created by update-mintify-docs-manually agent

---

**Update (scope expanded):** rebuilt linearly on `main` to clear the merge conflict, and added a table-of-contents fix across the how-to pages. Each `<Steps>` block now has a section heading before it (`Build the feed` / `Build the monitor` / `Set up Slack delivery`) and every `<Step>` uses `titleSize="h3"`, so the individual steps show as nested sub-points in "On this page" instead of being invisible. Verified in a local Mintlify render. Applies to `build-an-event-feed`, `monitor-a-portfolio`, and `send-events-to-slack`.