### PR TITLE
docs: add connection verification, cost notes, and setup gotchas to MCP page

### DIFF
--- a/web-search-api/integrations/mcp.mdx
+++ b/web-search-api/integrations/mcp.mdx
@@ -70,7 +70,7 @@ restart the client.
         Click **Add**. Verify that CatchAll appears under **Web** in your connectors list.
       </Step>
       <Step title="Test connection">
-        Open a new chat and ask Claude to run `check_health`. This tool needs no API key, so a successful response confirms the connection itself works — isolating connection problems from key problems. Then try a real query, for example: "Find AI company acquisitions in the last 7 days, limit 5". Claude should call the CatchAll tools and return structured results.
+        Open a new chat and ask Claude to run `check_health`. This tool needs no API key, so a successful response confirms the connection itself works — isolating connection problems from key problems. Then try a real query, for example: "Find AI company acquisitions in the last 7 days, limit 10". Claude should call the CatchAll tools and return structured results.
       </Step>
     </Steps>
 
@@ -175,7 +175,7 @@ restart the client.
         Run `claude mcp list` and confirm `catchall` is listed, or type `/mcp` inside a Claude Code session to see it marked as connected.
       </Step>
       <Step title="Test connection">
-        In a session, ask Claude to run `check_health`. This tool needs no API key, so a successful response confirms the connection works before you spend credits on a real query. Then try: "Find AI company acquisitions in the last 7 days, limit 5".
+        In a session, ask Claude to run `check_health`. This tool needs no API key, so a successful response confirms the connection works before you spend credits on a real query. Then try: "Find AI company acquisitions in the last 7 days, limit 10".
       </Step>
     </Steps>
 
@@ -384,7 +384,7 @@ explain this flow yourself.
 
 <Note>
   Jobs consume API credits in proportion to how many records they process. When
-  testing a new query, pass a small `limit` (for example, "limit 5") to keep
+  testing a new query, pass a small `limit` (for example, "limit 10") to keep
   cost low, then raise it or use `continue_job` once the results look right.
 </Note>
 

--- a/web-search-api/integrations/mcp.mdx
+++ b/web-search-api/integrations/mcp.mdx
@@ -36,6 +36,13 @@ uses option 2 (the `apiKey` query parameter) automatically. The tools
 To rotate your key, update your client configuration with the new key and
 restart the client.
 
+<Note>
+  When you pass the key through a `--header` flag (Claude Code, `mcp-remote`),
+  use the `header-name:value` format with no space after the colon — for
+  example `x-api-key:YOUR_CATCHALL_API_KEY`. A space or a missing colon is the
+  most common reason a connection silently fails to authenticate.
+</Note>
+
 <Warning>
   Your configuration file contains your API key in plain text. Treat it as a
   secret and do not share it or commit it to version control.
@@ -63,7 +70,7 @@ restart the client.
         Click **Add**. Verify that CatchAll appears under **Web** in your connectors list.
       </Step>
       <Step title="Test connection">
-        Open a new chat and type a CatchAll query, for example: "Find AI company acquisitions in the last 7 days, limit 5". Claude should call the CatchAll tools and return structured results.
+        Open a new chat and ask Claude to run `check_health`. This tool needs no API key, so a successful response confirms the connection itself works — isolating connection problems from key problems. Then try a real query, for example: "Find AI company acquisitions in the last 7 days, limit 5". Claude should call the CatchAll tools and return structured results.
       </Step>
     </Steps>
 
@@ -128,12 +135,18 @@ restart the client.
           }
         }
         ```
+
+        <Note>
+          On Windows, `npx` often cannot be launched directly from this config.
+          If the server fails to start, wrap it with `cmd`: set `"command":
+          "cmd"` and prepend `"/c", "npx"` to the `args` array.
+        </Note>
       </Step>
       <Step title="Restart Claude Desktop">
         Save the file and quit Claude Desktop completely, then relaunch it. Claude Desktop loads MCP tools on startup.
       </Step>
       <Step title="Verify connection">
-        Go to **Settings > Developer**. Next to **catchall**, the status should show **running**.
+        Go to **Settings > Developer**. Next to **catchall**, the status should show **running**. To confirm end to end, open a new chat and ask Claude to run `check_health` — it needs no API key, so a clean response proves the connection works.
       </Step>
     </Steps>
 
@@ -144,13 +157,23 @@ restart the client.
   </Tab>
 
   <Tab title="Claude Code">
-    Run in your terminal:
+    <Steps>
+      <Step title="Add the server">
+        Run in your terminal:
 
-    ```bash
-    claude mcp add --transport http catchall \
-      "https://catchall-mcp.newscatcherapi.com/mcp" \
-      --header "x-api-key:YOUR_CATCHALL_API_KEY"
-    ```
+        ```bash
+        claude mcp add --transport http catchall \
+          "https://catchall-mcp.newscatcherapi.com/mcp" \
+          --header "x-api-key:YOUR_CATCHALL_API_KEY"
+        ```
+      </Step>
+      <Step title="Verify connection">
+        Run `claude mcp list` and confirm `catchall` is listed, or type `/mcp` inside a Claude Code session to see it marked as connected.
+      </Step>
+      <Step title="Test connection">
+        In a session, ask Claude to run `check_health`. This tool needs no API key, so a successful response confirms the connection works before you spend credits on a real query. Then try: "Find AI company acquisitions in the last 7 days, limit 5".
+      </Step>
+    </Steps>
 
     <Tip>
       For Claude-specific features like the SKILL file and Python agents, see [Claude integration](/web-search-api/integrations/claude).
@@ -347,6 +370,17 @@ restart the client.
 
 Each tool maps to a CatchAll API endpoint. For request and response schemas, see
 the [API reference](/web-search-api/api-reference/jobs/create-job).
+
+The server ships usage guidance to the client automatically, so Claude already
+knows the job lifecycle — `submit_query` creates a job, `get_job_status` polls
+it, and `pull_results` retrieves records once it completes. You do not need to
+explain this flow yourself.
+
+<Note>
+  Jobs consume API credits in proportion to how many records they process. When
+  testing a new query, pass a small `limit` (for example, "limit 5") to keep
+  cost low, then raise it or use `continue_job` once the results look right.
+</Note>
 
 <Tabs>
   <Tab title="Jobs">

--- a/web-search-api/integrations/mcp.mdx
+++ b/web-search-api/integrations/mcp.mdx
@@ -136,6 +136,8 @@ restart the client.
         }
         ```
 
+        Write the header value as `x-api-key:YOUR_CATCHALL_API_KEY` with no space after the colon (see [Authentication](#authentication)).
+
         <Note>
           On Windows, `npx` often cannot be launched directly from this config.
           If the server fails to start, wrap it with `cmd`: set `"command":
@@ -166,6 +168,8 @@ restart the client.
           "https://catchall-mcp.newscatcherapi.com/mcp" \
           --header "x-api-key:YOUR_CATCHALL_API_KEY"
         ```
+
+        Keep the colon tight: `x-api-key:YOUR_CATCHALL_API_KEY` with no space after the colon, or the header is sent malformed (see [Authentication](#authentication)).
       </Step>
       <Step title="Verify connection">
         Run `claude mcp list` and confirm `catchall` is listed, or type `/mcp` inside a Claude Code session to see it marked as connected.
@@ -355,6 +359,8 @@ restart the client.
       }
     }
     ```
+
+    Write the header value as `x-api-key:YOUR_CATCHALL_API_KEY` with no space after the colon (see [Authentication](#authentication)).
 
     Restart your client after saving the configuration.
 


### PR DESCRIPTION
## Summary

Targeted improvements to the **CatchAll MCP server** integration page (`web-search-api/integrations/mcp.mdx`). The page was already strong (full per-tool tables, security warning, Node.js prereq, auth precedence, worked example). This PR closes the remaining first-run friction points: confirming a connection actually works, controlling cost, and two silent setup failures.

## Files changed

- `web-search-api/integrations/mcp.mdx`
  - **`check_health` smoke test** added to the verify/test steps for Claude.ai, Claude Desktop, and Claude Code. Because `check_health` needs no API key, it isolates connection problems from key problems — the cleanest first test.
  - **Claude Code tab → `<Steps>`** with an explicit verify step (`claude mcp list` / `/mcp`), matching the structure of the Claude.ai and Claude Desktop tabs (it was previously just a bare command).
  - **Header colon-syntax `<Note>`** in Authentication: `header-name:value` with no space after the colon. This is the most common reason a `--header` / `mcp-remote` connection silently fails to authenticate.
  - **Windows `cmd /c npx` `<Note>`** in the Claude Desktop config, where `npx` frequently can't be launched directly.
  - **Cost/credits `<Note>`** near *Available tools*: jobs consume credits proportional to records processed; use a small `limit` while testing. Explains the "limit 5" in the existing example.
  - **Auto-loaded usage guidance line**: notes the server ships the job lifecycle to the client, so users don't need to explain submit → poll → pull.

## Validation

- `python scripts/generate_llms_txt.py` and `generate_sitemap.py` both run clean; **no drift** in `llms.txt` or `sitemap.xml` (no `description` frontmatter or path changes, so derived files are unaffected).
- Edit confined to a single existing page — no new pages, no redirects needed.

## Reviewer checklist

- [ ] Content is accurate (esp. the Windows `cmd /c npx` guidance and `claude mcp list` / `/mcp` commands)
- [ ] `check_health` / `get_version` are confirmed no-auth on the deployed server
- [ ] Tone and component usage match house style

🤖 Generated with [Claude Code](https://claude.com/claude-code)