### PR TITLE
docs(local-news): correct article content field description

### DIFF
--- a/local-news-api/api-reference/local-news-api.yml
+++ b/local-news-api/api-reference/local-news-api.yml
@@ -1383,7 +1383,7 @@ components:
             image.
         content:
           type: string
-          description: A snippet or summary of the article's content.
+          description: The full content of the article.
         authors:
           type: array
           items:


### PR DESCRIPTION
## What

Fixes the `articles[].content` field description in the Local News API OpenAPI spec.

**Before:** `A snippet or summary of the article's content.`
**After:** `The full content of the article.`

## Why

The old wording implies the Local News API trims the article body to a snippet or summary. It does not. The field returns the **full extracted article text**, exactly like the News API `content` field.

A customer (Leithà / Unipol) flagged the discrepancy: the News API docs describe `content` as the full content, while the Local API docs called it "a snippet or summary", and they asked whether Local content gets trimmed.

## Verification

Tested both APIs live and compared articles present in both indexes:

- For every shared article, `content` matched **byte-for-byte** — same character count, same `word_count`.
- Example: a la Nazione markets article returned 2,104 chars / 330 words on **both** the Global and Local keys, identical.

So the field behaves identically across both products; only the description was wrong. This aligns the Local spec with the News API spec's `The content of the article.` while making the "full" nature explicit.

## Scope

Single-line change in `local-news-api/api-reference/local-news-api.yml`. The MDX reference pages are generated from this spec, so no other files need editing (the string appears only in this file).