### PR TITLE
docs(mcp): update MCP integration page

### DIFF
--- a/web-search-api/integrations/mcp.mdx
+++ b/web-search-api/integrations/mcp.mdx
@@ -431,6 +431,7 @@ explain this flow yourself.
     | `remove_webhook_resource` | Detach a webhook from a specific resource |
     | `list_resource_webhooks` | List all webhooks attached to a specific job or monitor |
     | `get_webhook_history` | Retrieve per-dispatch delivery outcomes and HTTP status codes |
+    | `trigger_webhook` | Manually trigger webhook delivery for a job, monitor, or monitor_group — dispatch is asynchronous; use `get_webhook_history` to see the outcome |
     | `delete_webhook` | Delete a webhook endpoint |
   </Tab>
 


### PR DESCRIPTION
## Automated Documentation Update

This PR was generated by the docs-review agent after a change was merged to `main` in `newscatcher-catchall-mcp`.

### What changed

- Added `trigger_webhook` to the Webhooks tools table in the "Available tools" section
- Tool manually triggers webhook delivery for a job, monitor, or monitor_group resource; dispatch is asynchronous and results can be checked with `get_webhook_history`

---
*Generated by `.github/scripts/docs_review_agent.py`*