### PR TITLE
docs(local-news): stop routing readers into the include_nlp_data 403

### DIFF
--- a/local-news-api/api-reference/local-news-api.yml
+++ b/local-news-api/api-reference/local-news-api.yml
@@ -1597,7 +1597,10 @@ components:
 
     NlpDataEntity:
       type: object
-      description: Natural Language Processing data for the article.
+      description: |
+        Natural Language Processing data for the article.
+
+        **Note**: The `nlp` object is returned by default on every Local News API subscription plan. Do not send `include_nlp_data`, which is a News API parameter that the Local News API endpoints reject with a `403`.
       properties:
         theme:
           type: array

--- a/local-news-api/get-started/quickstart.mdx
+++ b/local-news-api/get-started/quickstart.mdx
@@ -363,6 +363,9 @@ Now that you've made your first calls to the Local News API:
    [Search in translations](/news-api/how-to/search-in-translations) to
    find articles across languages using English keywords.
 4. Read about [NLP Enrichments](/news-api/guides-and-concepts/nlp-enrichments)
-   to extract insights from articles.
+   to extract insights from articles. Every Local News API plan returns the
+   `nlp` object by default, so skip the `include_nlp_data` parameter described
+   there: it applies to the News API only, and the Local News API endpoints
+   reject it with a `403`.
 
 <Note>Need help? Contact our support team at support@newscatcherapi.com</Note>

--- a/news-api/guides-and-concepts/nlp-enrichments.mdx
+++ b/news-api/guides-and-concepts/nlp-enrichments.mdx
@@ -9,6 +9,13 @@ NLP data before it is indexed: theme classification, sentiment scores, named
 entities, content tags, and vector embeddings. News API exposes these fields in
 the response when you set `include_nlp_data` to `true`.
 
+<Note>
+  `include_nlp_data` applies to the News API only. On the Local News API, the
+  `nlp` object is returned by default on every subscription plan, and sending
+  `include_nlp_data` returns
+  `403 Param include_nlp_data is not allowed for plan <plan_id>`.
+</Note>
+
 <Warning>
   NLP enrichment is available only for articles indexed from July 2023 onward.
   For earlier articles, the API returns `"nlp": {}`.


### PR DESCRIPTION
## The problem

The Local News API quickstart's **"What's next"** list, item 4, says:

> Read about [NLP Enrichments](/news-api/guides-and-concepts/nlp-enrichments) to extract insights from articles.

That link goes to a **News API** page, whose first paragraph says:

> News API exposes these fields in the response when you set `include_nlp_data` to `true`.

The Local News API rejects that parameter. Verified against a live key on `v3_local_news_nlp`:

```
POST https://local-news.newscatcherapi.com/api/search/advanced
  with include_nlp_data: true
  -> 403 {"message":"Param include_nlp_data is not allowed for plan v3_local_news_nlp"}

  without it
  -> 200, nlp fully populated (theme, sentiment, summary, ner_PER/ORG/LOC/MISC, new_embedding)
```

So following our own documented path produces a hard failure.

The reason it went unnoticed: `include_nlp_data` appeared **zero times** anywhere under `local-news-api/`, so nothing on the Local News side corrected the instruction. Meanwhile the reference pages document `articles[].nlp` and every child field under it, but never say how to make it appear. The answer is "it is already there," and that sentence existed nowhere.

Every Local News plan has Theme, Entity and Sentiment ticked on the [subscription plans](/local-news-api/get-started/subscription-plans) comparison table, so this is unconditional: no flag, ever, on any Local News plan.

## Changes

| File | Change |
|---|---|
| `local-news-api/get-started/quickstart.mdx` | Annotate the item-4 cross-link so readers know to skip the parameter |
| `news-api/guides-and-concepts/nlp-enrichments.mdx` | `<Note>` scoping the instruction to the News API, stating the Local News behaviour and the exact error |
| `local-news-api/api-reference/local-news-api.yml` | `**Note**` on the shared `NlpDataEntity` description |

The spec change is one edit on a shared schema, so it renders on **all five** Local News reference pages that expose `articles[].nlp`:

- `search/search-articles-post`
- `search/search-advanced-post`
- `latest-headlines/retrieve-latest-headlines-post`
- `latest-headlines/latest-headlines-advanced-post`
- `search-by/search-articles-by-identifiers-post`

It sits directly alongside the existing `new_embedding` plan note, so it lands in an established slot and matches house style.

## Why it matters

A production customer on `v3_local_news_nlp`, in week one of a signed contract, followed this exact path, burned four 403s, and opened a support thread. Because the error text reads *"not allowed for plan"*, it was misdiagnosed internally as a **plan entitlement gap** and carried that way for a week before anyone reproduced it. The plan was correct the whole time.

## Notes for reviewers

- No wording change to the existing News API instruction, which is accurate for the News API. It is only scoped.
- CI: ran `scripts/generate_llms_txt.py` and `scripts/generate_sitemap.py`, no drift. Only the three files change.
- `local-news-api.yml` re-parses cleanly and `NlpDataEntity` keeps all 12 properties; `BaseArticleEntity.nlp` is still a bare `$ref`, untouched.

## Out of scope

Two related items deliberately left out:

1. **The error wording itself.** `not allowed for plan` is what caused the misdiagnosis; something like *"`include_nlp_data` is not supported by the Local News API; NLP fields are returned by default"* would be self-explanatory. That is an API change, not a docs change.
2. **A full "News API parameters the Local News API rejects" list.** This is a per-plan parameter allowlist, and `include_similar_documents` fails identically, while `exclude_duplicates`, `include_translation_fields` and `is_headline` all pass. I only tested five parameters, and a table that is silently incomplete would be worse than none. Enumerating the real set means reading the gating config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
